### PR TITLE
updated forloops to for-from style recommended by cython instead of rely...

### DIFF
--- a/python-code/support-code/_sparsemat.pyx
+++ b/python-code/support-code/_sparsemat.pyx
@@ -151,10 +151,13 @@ cdef class PySparseMatFloat:
         """Return keys [(row,col)] similar to Python dict.keys()"""
         cdef items_float foo
         cdef Py_ssize_t i
+        cdef Py_ssize_t cur_length
+
+        cur_length = self.length()
         foo = self.thisptr.keys()
         
         results = []
-        for i in range(self.length()):
+        for i from 0 <= i < cur_length:
             results.append((foo.rows[i], foo.cols[i]))
                 
         return results
@@ -163,10 +166,13 @@ cdef class PySparseMatFloat:
         """Return items [((row,col),value)] similar to Python dict.items()"""
         cdef items_float foo
         cdef Py_ssize_t i
+        cdef Py_ssize_t cur_length
+
+        cur_length = self.length()
         foo = self.thisptr.items()
         
         results = []
-        for i in range(self.length()):
+        for i from 0 <= i < cur_length:
             results.append(((foo.rows[i], foo.cols[i]), foo.values[i]))
                 
         return results
@@ -275,11 +281,13 @@ cdef class PySparseMatInt:
         """Return keys [(row,col)] similar to Python dict.keys()"""
         cdef items_int foo
         cdef Py_ssize_t i
-        
+        cdef Py_ssize_t cur_length
+
+        cur_length = self.length()
         foo = self.thisptr.keys()
         
         results = []
-        for i in range(self.length()):
+        for i from 0 <= i < cur_length:
             results.append((foo.rows[i], foo.cols[i]))
                 
         return results
@@ -288,11 +296,13 @@ cdef class PySparseMatInt:
         """Return items [((row,col),value)] similar to Python dict.items()"""
         cdef items_int foo
         cdef Py_ssize_t i
+        cdef Py_ssize_t cur_length
         
+        cur_length = self.length()
         foo = self.thisptr.items()
         
         results = []
-        for i in range(self.length()):
+        for i from 0 <= i < cur_length:
             results.append(((foo.rows[i], foo.cols[i]), foo.values[i]))
                 
         return results


### PR DESCRIPTION
Was reading through the Cython [overview](https://github.com/cython/cython/blob/master/Doc/overview.html) (or a different but readable version [here](http://wiki.cython.org/loops)) on the plane today about avoiding using `range()` within Cython forloops as it still uses the rich Python API. Using the for-from syntax allows for basically a 1-1 mapping directly to C. Should improve `keys()` and `items()` performance a good amount, and these are blocks of code used extensively in `SparseMat`.

On a side note, did anyone know that Python accepts a for-else statement?

``` python
for i in range(10):
  print i
else:
  print "foo"
```
