### PR TITLE
to_sparsemat now handles numpy matrices

### DIFF
--- a/python-code/biom/sparsemat.py
+++ b/python-code/biom/sparsemat.py
@@ -232,6 +232,12 @@ def to_sparsemat(values, transpose=False, dtype=float):
         else:
             mat = nparray_to_sparsemat(values, dtype)
         return mat
+    if isinstance(values, ndarray):
+        if transpose:
+            mat = nparray_to_sparsemat(values.T, dtype)
+        else:
+            mat = nparray_to_sparsemat(values, dtype)
+        return mat 
     # the empty list
     elif isinstance(values, list) and len(values) == 0:
         mat = SparseMat(0,0)


### PR DESCRIPTION
further fixes #95, didn't realize this problem extended beyond `to_csmat`
