### PR TITLE
Fix add_metadata.py when existing metadata

### DIFF
--- a/python-code/biom/table.py
+++ b/python-code/biom/table.py
@@ -183,7 +183,8 @@ class Table(object):
         """
         if self.ObservationMetadata != None:
             for id_, md_entry in md.items():
-                self.ObservationMetadata[self.getObservationIndex(id_)].update(md_entry)
+                if self.observationExists(id_):
+                    self.ObservationMetadata[self.getObservationIndex(id_)].update(md_entry)
         else:
             super(Table, self).__setattr__('ObservationMetadata',
                     tuple([md[id_] for id_ in self.ObservationIds]))
@@ -196,7 +197,8 @@ class Table(object):
         """
         if self.SampleMetadata != None:
             for id_, md_entry in md.items():
-                self.SampleMetadata[self.getSampleIndex(id_)].update(md_entry)
+                if self.sampleExists(id_):
+                    self.SampleMetadata[self.getSampleIndex(id_)].update(md_entry)
         else:
             super(Table, self).__setattr__('SampleMetadata',
                     tuple([md[id_] for id_ in self.SampleIds]))

--- a/python-code/tests/test_table.py
+++ b/python-code/tests/test_table.py
@@ -413,7 +413,8 @@ class TableTests(TestCase):
         self.assertEqual(t.ObservationMetadata[2]['a'],7)
         obs_md = {1:{'taxonomy':['A','B']},
                   2:{'taxonomy':['B','C']},
-                  3:{'taxonomy':['E','D','F']}}
+                  3:{'taxonomy':['E','D','F']},
+                  4:{'taxonomy':['this','is','ignored']}}
         t.addObservationMetadata(obs_md)
         self.assertEqual(t.ObservationMetadata[0]['a'],9)
         self.assertEqual(t.ObservationMetadata[1]['a'],8)
@@ -474,7 +475,8 @@ class TableTests(TestCase):
         samp_md = {4:{'barcode':'TTTT'},
                    6:{'barcode':'AAAA'},
                    5:{'barcode':'GGGG'},
-                   7:{'barcode':'CCCC'}}
+                   7:{'barcode':'CCCC'},
+                   10:{'ignore':'me'}}
         t.addSampleMetadata(samp_md)
         self.assertEqual(t.SampleMetadata[0]['Treatment'],'Control')
         self.assertEqual(t.SampleMetadata[1]['Treatment'],'Fasting')


### PR DESCRIPTION
Fixes #120
This bug occured for both samples and observations.
Tests have been altered to test for case when extra metadata is given.
