### PR TITLE
Allow adding of complex metadata

### DIFF
--- a/scripts/add_metadata.py
+++ b/scripts/add_metadata.py
@@ -92,7 +92,7 @@ def float_(x):
         return x
 
 def split_on_semicolons_and_pipes(x):
-    return [y.split(';') for y in x.split('|')]
+    return [[e.strip() for e in y.split(';')] for y in x.split('|')]
 
 def main():
     opts,args = parser.parse_args()


### PR DESCRIPTION
Add option to add_metadata.py (--sc_pipe_separated),
to allow metadata field to be added as list of lists,
instead of just list of strings as done by --sc_separated.

This is useful when there is a one to many mapping (e.g. KOs to
KEGG Pathways). PICRUSt can use this metadata format when using the 
categorize_by_function.py.

Example:

L1_A;L2_B;L3_C|L1_A;L2_D
becomes
[[L1_A,L2_B,L3_C],[L1_A,L2_D]]
