### PR TITLE
Clean up sparse backend type reporting

### DIFF
--- a/biom/backends/csmat.py
+++ b/biom/backends/csmat.py
@@ -25,7 +25,7 @@ __version__ = "1.2.0-dev"
 __maintainer__ = "Daniel McDonald"
 __email__ = "daniel.mcdonald@colorado.edu"
 
-class CSMat():
+class CSMat(object):
     """Compressed sparse (CSR/CSC) and coordinate list (COO) formats.
 
     Builds sparse matrix in COO format first (good for incremental

--- a/biom/commands/installation_informer.py
+++ b/biom/commands/installation_informer.py
@@ -99,13 +99,14 @@ class InstallationInformer(Command):
         try:
             from biom.exception import InvalidSparseBackendException
             from biom.table import SparseObj
+            backend_name = SparseObj(0, 0).__class__.__name__
         except ImportError:
-            SparseObj = import_error_msg
+            backend_name = import_error_msg
         except InvalidSparseBackendException as e:
-            SparseObj = "ERROR: %s" % e
+            backend_name = "ERROR: %s" % e
 
         return (("biom-format version", biom_lib_version),
-                ("SparseObj type", SparseObj))
+                ("SparseObj type", backend_name))
 
     def _format_info(self, info, title):
         max_len = self._get_max_length(info)

--- a/doc/documentation/change_sparse_backend.rst
+++ b/doc/documentation/change_sparse_backend.rst
@@ -28,7 +28,7 @@ To check what sparse matrix backend is in use, simply execute ``biom show-instal
  biom-format package information
  ===============================
  biom-format version:	1.2.0
-      SparseObj type:	biom.backends.csmat.CSMat
+      SparseObj type:	CSMat
 
 The last line indicates that the ``CSMat`` sparse matrix backend is in use.
 


### PR DESCRIPTION
The discrepancy in sparse backend type reporting between CSMat and ScipySparseMat occurred because CSMat was an old-style class and ScipySparseMat is new-style (inherits from object). This caused the formatting of the class name to differ. CSMat is now a new-style class.

The new output for both backends looks like:

```
 SparseObj type: CSMat
 SparseObj type: ScipySparseMat
```

This is a bit cleaner/clearer than what we had before (e.g., biom.backends.csmat.CSMat), since users are really only concerned with the name of the backend. The backend name output by `biom show-install-info` is now consistent with the name users must add to their BIOM config file.

Fixes #231.
