### PR TITLE
added Table.nonzeroCounts

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -1179,6 +1179,38 @@ class Table(object):
             for s_idx in samp_vals.nonzero()[0]:
                 yield (self.ObservationIds[o_idx], self.SampleIds[s_idx])
 
+    def nonzeroCounts(self, axis, binary=False):
+        """Get nonzero summaries about an axis
+
+        axis : either 'sample', 'observation', or 'whole'
+        binary : sum of nonzero entries, or summing the values of the entries
+        
+        Returns a numpy array in index order to the axis
+        """
+        if binary:
+            dtype = 'int'
+            op = lambda x: x.nonzero()[0].size
+        else:
+            dtype = self._data.dtype
+            op = lambda x: x.sum()
+
+        if axis is 'sample':
+            # can use np.bincount for CSMat or ScipySparse
+            result = zeros(len(self.SampleIds), dtype=dtype)
+            for idx, vals in enumerate(self.iterSampleData()):
+                result[idx] = op(vals)
+        elif axis is 'observation':
+            # can use np.bincount for CSMat or ScipySparse
+            result = zeros(len(self.ObservationIds), dtype=dtype)
+            for idx, vals in enumerate(self.iterObservationData()):
+                result[idx] = op(vals)
+        else:
+            result = zeros(1, dtype=dtype)
+            for vals in self.iterSampleData():
+                result[0] += op(vals)
+
+        return result
+
     def _union_id_order(self, a, b):
         """Determines merge order for id lists A and B"""
         all_ids = list(a[:])

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1953,6 +1953,44 @@ class SparseTableTests(TestCase):
         obs = list(st.nonzero())
         self.assertEqual(obs, exp)
 
+    def test_nonzeroCounts(self):
+        """Returns nonzero counts over an axis"""
+        data = {(0,0):5,(0,1):6,(0,2):0,(0,3):3,
+                (1,0):0,(1,1):7,(1,2):0,(1,3):8,
+                (2,0):1,(2,1):-1,(2,2):0,(2,3):0}
+        st = SparseTable(to_sparse(data), ['a','b','c','d'],['1','2','3'])
+        
+        exp_samp = array([6, 12, 0, 11])
+        exp_obs = array([14, 15, 0])
+        exp_whole = array([29])
+
+        obs_samp = st.nonzeroCounts('sample')
+        obs_obs = st.nonzeroCounts('observation')
+        obs_whole = st.nonzeroCounts('whole')
+
+        self.assertEqual(obs_samp, exp_samp)
+        self.assertEqual(obs_obs, exp_obs)
+        self.assertEqual(obs_whole, exp_whole)
+
+    def test_nonzeroCounts_binary(self):
+        """Returns nonzero counts over an axis"""
+        data = {(0,0):5,(0,1):6,(0,2):0,(0,3):3,
+                (1,0):0,(1,1):7,(1,2):0,(1,3):8,
+                (2,0):1,(2,1):-1,(2,2):0,(2,3):0}
+        st = SparseTable(to_sparse(data), ['a','b','c','d'],['1','2','3'])
+        
+        exp_samp = array([2, 3, 0, 2])
+        exp_obs = array([3, 2, 2])
+        exp_whole = array([7])
+
+        obs_samp = st.nonzeroCounts('sample', binary=True)
+        obs_obs = st.nonzeroCounts('observation', binary=True)
+        obs_whole = st.nonzeroCounts('whole', binary=True)
+
+        self.assertEqual(obs_samp, exp_samp)
+        self.assertEqual(obs_obs, exp_obs)
+        self.assertEqual(obs_whole, exp_whole)
+    
     def test_merge(self):
         """Merge two tables"""
         u = 'union'


### PR DESCRIPTION
- counts over axes
- can be optimized much further for sparse matrices
- did not test for dense as we are dropping support
