### PR TITLE
Fix pyqi dependency link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(name='biom-format',
     install_requires=["numpy >= 1.3.0",
                       "pyqi == 0.3.1-dev"],
     dependency_links=[
-        "git+https://github.com/bipy/pyqi.git#egg=pyqi-0.3.1-dev"
+        'https://github.com/bipy/pyqi/archive/master.zip#egg=pyqi-0.3.1-dev'
     ],
     extras_require={'scipy_sparse':["scipy >= 0.9.0"],
                     'test':["nose >= 0.10.1",


### PR DESCRIPTION
Some versions of setuptools don't support the git+https URL scheme in `dependency_links`, so `python setup.py install` doesn't work (even though `pip install .` does work). Updating the link to point to GitHub's .zip archive of latest pyqi master seems to work (with both pip and setup.py installation).
