### PR TITLE
Add support for list of list of values -> table

### DIFF
--- a/biom/backends/scipysparse.py
+++ b/biom/backends/scipysparse.py
@@ -422,6 +422,9 @@ def list_list_to_scipy(data, dtype=float, shape=None):
         n_cols = len(data[0])
         return ScipySparseMat(n_rows, n_cols, data=data)
 
+    else:
+        raise TableException("Cannot understand input data.")
+
 
 def nparray_to_scipy(data, dtype=float):
     """Convert a numpy array to a ``ScipySparseMat``."""


### PR DESCRIPTION
Previously, `biom.backends.scipysparse.list_list_to_scipy` assumed the input was `[[rows], [cols], [values]]`.  Now it also supports input data of the form `[[row 1 values], [row 2 values], ..., [row N values]]` (in other words, a dense table)
