### PR TITLE
Add Table.index method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
   - source activate env_name
   - pip install -r requirements.txt .
 script:
-  - nosetests
+  - nosetests --with-doctest
   - pep8 biom setup.py
   - biom show-install-info

--- a/biom/commands/table_converter.py
+++ b/biom/commands/table_converter.py
@@ -27,8 +27,6 @@ __email__ = "gregcaporaso@gmail.com"
 
 
 class TableConverter(Command):
-    MatrixTypes = ['sparse', 'dense']
-
     ObservationMetadataTypes = {
         'sc_separated': lambda x: [e.strip() for e in x.split(';')],
         'naive': lambda x: x

--- a/biom/exception.py
+++ b/biom/exception.py
@@ -31,8 +31,17 @@ class TableException(BiomException):
     pass
 
 
-class UnknownID(BiomException):
-    pass
+class UnknownAxisError(TableException):
+    def __init__(self, axis):
+        super(UnknownAxisError, self).__init__()
+        self.args = ("Unknown axis '%s'." % axis,)
+
+
+class UnknownIDError(TableException):
+    def __init__(self, missing_id, axis):
+        super(UnknownIDError, self).__init__()
+        self.args = ("The %s ID '%s' could not be found in the BIOM table." %
+                     (axis, missing_id),)
 
 
 class InvalidSparseBackendException(BiomException):

--- a/biom/interfaces/html/config/convert.py
+++ b/biom/interfaces/html/config/convert.py
@@ -37,11 +37,6 @@ inputs = [
                     Type='upload_file',
                     Help='the input table filepath, either in BIOM or classic '
                     'format'),
-    HTMLInputOption(Parameter=cmd_in_lookup('matrix_type'),
-                    Type='multiple_choice',
-                    Choices=['sparse', 'dense'],
-                    Help='the type of BIOM file to create when a classic '
-                    'table is supplied'),
     HTMLInputOption(Parameter=cmd_in_lookup('biom_to_classic_table'),
                     Type=bool),
     HTMLInputOption(Parameter=cmd_in_lookup('sparse_biom_to_dense_biom'),
@@ -61,19 +56,6 @@ inputs = [
                     Choices=['taxonomy', 'naive', 'sc_separated'],
                     Help='Process metadata associated with observations when '
                     'converting from a classic table'),
-    HTMLInputOption(Parameter=cmd_in_lookup('table_type'),
-                    Type='multiple_choice',
-                    Choices=[
-                        'metabolite table',
-                        'gene table',
-                        'otu table',
-                        'pathway table',
-                        'function table',
-                        'ortholog table',
-                        'taxon table'],
-                    Help='The BIOM table type to get converted into. Required '
-                    'when converting a classic table file to a BIOM table '
-                    'file.'),
     HTMLInputOption(Parameter=None,
                     Name='download-file',
                     Required=True,

--- a/tests/test_commands/test_metadata_adder.py
+++ b/tests/test_commands/test_metadata_adder.py
@@ -41,11 +41,11 @@ class MetadataAdderTests(TestCase):
         self.assertEqual(obs.keys(), ['table'])
 
         obs = obs['table']
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('f4')],
+        self.assertEqual(obs.sample_metadata[obs.index('f4', 'sample')],
                          {'bar': '0.23', 'foo': '9', 'baz': 'abc;123'})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('not16S.1')],
+        self.assertEqual(obs.sample_metadata[obs.index('not16S.1', 'sample')],
                          {'bar': '-4.2', 'foo': '0', 'baz': '123;abc'})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('f2')], {})
+        self.assertEqual(obs.sample_metadata[obs.index('f2', 'sample')], {})
 
     def test_add_sample_metadata_with_casting(self):
         """Correctly adds sample metadata with casting."""
@@ -56,11 +56,11 @@ class MetadataAdderTests(TestCase):
         self.assertEqual(obs.keys(), ['table'])
 
         obs = obs['table']
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('f4')],
+        self.assertEqual(obs.sample_metadata[obs.index('f4', 'sample')],
                          {'bar': 0.23, 'foo': 9, 'baz': ['abc', '123']})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('not16S.1')],
+        self.assertEqual(obs.sample_metadata[obs.index('not16S.1', 'sample')],
                          {'bar': -4.2, 'foo': 0, 'baz': ['123', 'abc']})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('f2')], {})
+        self.assertEqual(obs.sample_metadata[obs.index('f2', 'sample')], {})
 
     def test_add_observation_metadata_no_casting(self):
         """Correctly adds observation metadata without casting it."""
@@ -74,13 +74,13 @@ class MetadataAdderTests(TestCase):
 
         obs = obs['table']
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('None7')],
+            obs.observation_metadata[obs.index('None7', 'observation')],
             {'foo': '6', 'taxonomy': 'abc;123|def;456'})
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('879972')],
+            obs.observation_metadata[obs.index('879972', 'observation')],
             {'foo': '3', 'taxonomy': '123;abc|456;def'})
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('None8')],
+            obs.observation_metadata[obs.index('None8', 'observation')],
             {'taxonomy': ['k__Bacteria']})
 
     def test_add_observation_metadata_with_casting(self):
@@ -92,13 +92,13 @@ class MetadataAdderTests(TestCase):
 
         obs = obs['table']
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('None7')],
+            obs.observation_metadata[obs.index('None7', 'observation')],
             {'foo': 6, 'taxonomy': [['abc', '123'], ['def', '456']]})
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('879972')],
+            obs.observation_metadata[obs.index('879972', 'observation')],
             {'foo': 3, 'taxonomy': [['123', 'abc'], ['456', 'def']]})
         self.assertEqual(
-            obs.observation_metadata[obs.get_observation_index('None8')],
+            obs.observation_metadata[obs.index('None8', 'observation')],
             {'taxonomy': ['k__Bacteria']})
 
     def test_no_metadata(self):

--- a/tests/test_commands/test_table_converter.py
+++ b/tests/test_commands/test_table_converter.py
@@ -62,12 +62,12 @@ class TableConverterTests(TestCase):
         self.assertEqual(len(obs.observation_ids), 14)
         self.assertNotEqual(obs.sample_metadata, None)
         self.assertNotEqual(obs.observation_metadata, None)
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('p2')],
+        self.assertEqual(obs.sample_metadata[obs.index('p2', 'sample')],
                          {'foo': 'c;b;a'})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('not16S.1')],
+        self.assertEqual(obs.sample_metadata[obs.index('not16S.1', 'sample')],
                          {'foo': 'b;c;d'})
         self.assertEqual(obs.observation_metadata[
-            obs.get_observation_index('None11')],
+            obs.index('None11', 'observation')],
             {'taxonomy': 'Unclassified'})
 
         # With processing of metadata (currently only supports observation md).
@@ -82,12 +82,12 @@ class TableConverterTests(TestCase):
         self.assertEqual(len(obs.observation_ids), 14)
         self.assertNotEqual(obs.sample_metadata, None)
         self.assertNotEqual(obs.observation_metadata, None)
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('p2')],
+        self.assertEqual(obs.sample_metadata[obs.index('p2', 'sample')],
                          {'foo': 'c;b;a'})
-        self.assertEqual(obs.sample_metadata[obs.get_sample_index('not16S.1')],
+        self.assertEqual(obs.sample_metadata[obs.index('not16S.1', 'sample')],
                          {'foo': 'b;c;d'})
         self.assertEqual(obs.observation_metadata[
-            obs.get_observation_index('None11')],
+            obs.index('None11', 'observation')],
             {'taxonomy': ['Unclassified']})
 
     def test_biom_to_classic(self):


### PR DESCRIPTION
Replaces `Table.get_sample_index` and `Table.get_observation_index`.

Also fixed some unrelated issues with broken code that `nosetests --with-doctest` uncovered.

Fixes #322.
