### PR TITLE
ENH: Table._to_dense is now static

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -98,7 +98,8 @@ class Table(object):
         else:
             return to_sparse(vals, transpose, dtype)
 
-    def _to_dense(self, vec):
+    @staticmethod
+    def _to_dense(vec):
         """Converts a row/col vector to a dense numpy array.
 
         Always returns a 1-D row vector for consistency with numpy iteration


### PR DESCRIPTION
Partially addresses a point in #319. I don't know if it makes sense to have `_to_dense` be public, I can see reasons for and against. 
