### PR TITLE
ENH: Add h5py version and remove backend info

### DIFF
--- a/biom/commands/installation_informer.py
+++ b/biom/commands/installation_informer.py
@@ -83,9 +83,17 @@ class InstallationInformer(Command):
         except ImportError:
             scipy_lib_version = not_installed_msg
 
+        try:
+            from h5py import __version__ as h5py_lib_version
+        except ImportError:
+            h5py_lib_version = ("WARNING: Not installed - this is an optional "
+                                "dependency. It is strongly recommended for "
+                                "large datasets.")
+
         return (("pyqi version", pyqi_lib_version),
                 ("NumPy version", numpy_lib_version),
-                ("SciPy version", scipy_lib_version))
+                ("SciPy version", scipy_lib_version),
+                ("h5py version", h5py_lib_version))
 
     def get_package_info(self):
         import_error_msg = ("ERROR: Can't find the BIOM library code (or "
@@ -96,17 +104,7 @@ class InstallationInformer(Command):
         except ImportError:
             biom_lib_version = import_error_msg
 
-        try:
-            from biom.exception import InvalidSparseBackendException
-            from biom.table import SparseObj
-            backend_name = SparseObj(0, 0).__class__.__name__
-        except ImportError:
-            backend_name = import_error_msg
-        except InvalidSparseBackendException as e:
-            backend_name = "ERROR: %s" % e
-
-        return (("biom-format version", biom_lib_version),
-                ("SparseObj type", backend_name))
+        return (("biom-format version", biom_lib_version),)
 
     def _format_info(self, info, title):
         max_len = self._get_max_length(info)


### PR DESCRIPTION
This information has been removed from the string displayed in:

```
$ biom show-install-info
```

The information now looks like this:

```
System information
```

   ==================
   Platform: darwin
   Python/GCC version:   2.7.6 (v2.7.6:3a1db0d2747e, Nov 10 2013,
           00:42:54)  [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
   Python executable:
   /Users/yoshikivazquezbaeza/.virtualenvs/biom-dev/bin/python

```
Dependency versions
```

   ===================
   pyqi version:   0.3.1
   NumPy version:  1.7.1
   SciPy version:  0.13.3
   h5py version:  2.3.0

```
biom-format package information
```

   ===============================
   biom-format version:   1.3.1-dev

In case h5py is not installed, it will look like this:

```
System information
```

   ==================
   Platform: darwin
   Python/GCC version:   2.7.6 (v2.7.6:3a1db0d2747e, Nov 10 2013,
           00:42:54)  [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
   Python executable:
   /Users/yoshikivazquezbaeza/.virtualenvs/biom-dev/bin/python

```
Dependency versions
```

   ===================
   pyqi version:   0.3.1
   NumPy version:  1.7.1
   SciPy version:  0.13.3
   h5py version: WARNING: Not installed - this is an optional dependency.
   It is strongly recommended for large datasets.

```
biom-format package information
```

   ===============================
   biom-format version:   1.3.1-dev
