### PR TITLE
Add Fork me on GitHub banner

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,5 +1,14 @@
 {% extends "!layout.html" %}
 
+{# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
+{% block header %}
+  {{ super() }}
+  <a href="https://github.com/biocore/biom-format"><img
+    style="position: absolute; top: 0; right: 0; border: 0;"
+    src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"
+    alt="Fork me on GitHub"></a>
+{% endblock %}
+
 {# include the Google Analytics Tracker #}
 {% block footer %}
 {{ super() }}


### PR DESCRIPTION
Here's what it looks like:

![screenshot from 2014-05-14 15 55 39](https://cloud.githubusercontent.com/assets/1847232/2978581/75ebceda-dbbb-11e3-8ef2-f4c030f7a1ef.png)

I added a link in the code with all available colors and orientations- not sold on this particular color or placement, but should be a good proof-of-concept to work off of.

Fixes #281.
