### PR TITLE
ENH: example_table, Table and parse_table available from package

### DIFF
--- a/biom/__init__.py
+++ b/biom/__init__.py
@@ -20,4 +20,17 @@ __version__ = "1.3.1-dev"
 __maintainer__ = "Daniel McDonald"
 __email__ = "daniel.mcdonald@colorado.edu"
 
-__all__ = ['table', 'parse', 'util', 'exception']
+
+from .table import Table
+from .parse import parse_biom_table as parse_table
+
+example_table = Table([[0, 1, 2], [3, 4, 5]], ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'],
+                      [{'taxonomy': ['Bacteria', 'Firmicutes']},
+                       {'taxonomy': ['Bacteria', 'Bacteroidetes']}],
+                      [{'environment': 'A'},
+                       {'environment': 'B'},
+                       {'environment': 'A'}], input_is_dense=True)
+
+
+__all__ = ['Table', 'example_table', 'parse_table']


### PR DESCRIPTION
Some convenience for the package level `__init__` and an example table. The example table is handy if you just want something quick to play with in an interpreter.

``` python
>>> from biom import example_table
>>> print example_table
# Constructed from biom file
#OTU ID S1  S2  S3
O1  0.0 1.0 2.0
O2  3.0 4.0 5.0
>>> from biom import Table
>>> print Table
<class 'biom.table.Table'>
>>> from biom import parse_table
>>> print parse_table
<function parse_biom_table at 0x1076d7b18>
```
