### PR TITLE
DOC: Fix doc pointing to non-existent method

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -2753,7 +2753,7 @@ html
 
         See Also
         --------
-        Table.format_hdf5
+        Table.from_hdf5
 
         References
         ----------


### PR DESCRIPTION
Table.format_hdf5 does not exist. 😱
