### PR TITLE
BUG: subsample can now handle metadata

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -1935,15 +1935,8 @@ class Table(object):
 
         _subsample(data, n)
 
-        if self.sample_metadata is None:
-            samp_md = None
-        else:
-            samp_md = self.sample_metadata.copy()
-
-        if self.observation_metadata is None:
-            obs_md = None
-        else:
-            obs_md = self.observation_metadata.copy()
+        samp_md = deepcopy(self.sample_metadata)
+        obs_md = deepcopy(self.observation_metadata)
 
         table = Table(data, self.observation_ids.copy(),
                       self.sample_ids.copy(), obs_md, samp_md)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1693,6 +1693,14 @@ class SparseTableTests(TestCase):
         self.assertEqual(actual_o2, {(0, 3, 3), (0, 2, 3), (0, 3, 2),
                                      (0, 2, 2)})
 
+    def test_subsample_md_copy_bug(self):
+        """subsample would except when if metadata were present"""
+        table = Table(np.array([[5, 5, 5]]), ['O1'], ['S1', 'S2', 'S3'],
+                      [{'foo': 'bar'}], [{1: 2}, {3: 4}, {5: 6}])
+        exp = table.copy()
+        obs = table.subsample(5)
+        self.assertEqual(obs, exp)
+
     def test_pa(self):
         exp = Table(np.array([[1, 1], [1, 0]]), ['5', '6'], ['a', 'b'])
         self.st7.pa()


### PR DESCRIPTION
The `.copy()` on sample and observation metadata didn't work as `tuple`s don't have a copy method
