### PR TITLE
BUG: Use load_table in convert_biom_to_table

### DIFF
--- a/biom/__init__.py
+++ b/biom/__init__.py
@@ -62,7 +62,7 @@ __email__ = "daniel.mcdonald@colorado.edu"
 
 
 from .table import Table
-from .parse import parse_biom_table as parse_table
+from .parse import parse_biom_table as parse_table, load_table
 
 example_table = Table([[0, 1, 2], [3, 4, 5]], ['O1', 'O2'],
                       ['S1', 'S2', 'S3'],
@@ -71,43 +71,6 @@ example_table = Table([[0, 1, 2], [3, 4, 5]], ['O1', 'O2'],
                       [{'environment': 'A'},
                        {'environment': 'B'},
                        {'environment': 'A'}], input_is_dense=True)
-
-
-def load_table(f):
-    r"""Load a `Table` from a path
-
-    Parameters
-    ----------
-    f : str
-
-    Returns
-    -------
-    Table
-
-    Raises
-    ------
-    IOError
-        If the path does not exist
-    TypeError
-        If the data in the path does not appear to be a BIOM table
-
-    Examples
-    --------
-    Parse a table from a path. BIOM will attempt to determine if the fhe file
-    is either in TSV, HDF5, JSON, gzip'd JSON or gzip'd TSV and parse
-    accordingly:
-
-    >>> from biom import load_table
-    >>> table = load_table('path/to/table.biom') # doctest: +SKIP
-
-    """
-    from biom.util import biom_open
-    with biom_open(f) as fp:
-        try:
-            table = parse_table(fp)
-        except (IndexError, TypeError):
-            raise TypeError("%s does not appear to be a BIOM file!" % f)
-    return table
 
 
 __all__ = ['Table', 'example_table', 'parse_table', 'load_table']

--- a/biom/parse.py
+++ b/biom/parse.py
@@ -14,6 +14,7 @@ import numpy as np
 from biom import __version__
 from biom.exception import BiomParseException, UnknownAxisError
 from biom.table import Table
+from biom.util import biom_open
 import json
 
 __author__ = "Justin Kuczynski"
@@ -497,7 +498,7 @@ def biom_meta_to_string(metadata, replace_str=':'):
 def convert_biom_to_table(biom_f, header_key=None, header_value=None,
                           md_format=None):
     """Convert a biom table to a contigency table"""
-    table = parse_biom_table(biom_f)
+    table = load_table(biom_f)
     if md_format is None:
         md_format = biom_meta_to_string
 
@@ -510,3 +511,39 @@ def convert_biom_to_table(biom_f, header_key=None, header_value=None,
                                     metadata_formatter=md_format)
     else:
         return table.delimited_self()
+
+
+def load_table(f):
+    r"""Load a `Table` from a path
+
+    Parameters
+    ----------
+    f : str
+
+    Returns
+    -------
+    Table
+
+    Raises
+    ------
+    IOError
+        If the path does not exist
+    TypeError
+        If the data in the path does not appear to be a BIOM table
+
+    Examples
+    --------
+    Parse a table from a path. BIOM will attempt to determine if the fhe file
+    is either in TSV, HDF5, JSON, gzip'd JSON or gzip'd TSV and parse
+    accordingly:
+
+    >>> from biom import load_table
+    >>> table = load_table('path/to/table.biom') # doctest: +SKIP
+
+    """
+    with biom_open(f) as fp:
+        try:
+            table = parse_biom_table(fp)
+        except (IndexError, TypeError):
+            raise TypeError("%s does not appear to be a BIOM file!" % f)
+    return table


### PR DESCRIPTION
convert_biom_to_table was using parse_biom_table, but was missing on a lot of
the useful functionality that load_table provides. This was causing a bug in a
QIIME script that tried to load an HDF5 file using convert_biom_to_table.

Note that I moved load_table to biom/util.py but the interface will remain the
same i. e. you can still do:

``` python
from biom import load_table
```
