### PR TITLE
fixing issue_504

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -3616,6 +3616,9 @@ html
             t_md_name) = Table._extract_data_from_tsv(lines, **kwargs)
 
         # if we have it, keep it
+        if t_md_name == 'taxonomy':
+            process_func = lambda x: [e.strip() for e in x.split(';')]
+
         if t_md is None:
             obs_metadata = None
         else:


### PR DESCRIPTION
Fixes #504

`taxonomy` is now a controlled header. Thus, it makes sense to already parse it in the correct way, just in case the user forgets to provide the `--process-obs-metadata taxonomy` parameter in `biom convert`.
