### PR TITLE
Collapse stores a list of original ids

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -2926,6 +2926,7 @@ dataset of int32
 
         - taxonomy: (N, ?) dataset of str or vlen str
         - KEGG_Pathways: (N, ?) dataset of str or vlen str
+        - collapsed_ids: (N, ?) dataset of str or vlen str
 
         Parameters
         ----------
@@ -3008,6 +3009,7 @@ html
             parser = defaultdict(lambda: general_parser)
             parser['taxonomy'] = vlen_list_of_str_parser
             parser['KEGG_Pathways'] = vlen_list_of_str_parser
+            parser['collapsed_ids'] = vlen_list_of_str_parser
             # fetch all of the metadata
             md = []
             for i in range(len(ids)):
@@ -3188,6 +3190,7 @@ dataset of int32
 
         - taxonomy: (N, ?) dataset of str or vlen str
         - KEGG_Pathways: (N, ?) dataset of str or vlen str
+        - collapsed_ids: (N, ?) dataset of str or vlen str
 
         Parameters
         ----------
@@ -3299,6 +3302,7 @@ html
                 formatter = defaultdict(lambda: general_formatter)
                 formatter['taxonomy'] = vlen_list_of_str_formatter
                 formatter['KEGG_Pathways'] = vlen_list_of_str_formatter
+                formatter['collapsed_ids'] = vlen_list_of_str_formatter
                 # Loop through all the categories
                 for category in md[0]:
                     # Create the dataset for the current category,

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -535,6 +535,47 @@ class TableTests(TestCase):
         obs = Table.from_hdf5(h5)
         self.assertEqual(obs, self.st_rich)
 
+        # Test with a collapsed table
+        fname = mktemp()
+        self.to_remove.append(fname)
+        h5 = h5py.File(fname, 'w')
+        dt_rich = Table(
+            np.array([[5, 6, 7], [8, 9, 10], [11, 12, 13]]),
+            ['1', '2', '3'], ['a', 'b', 'c'],
+            [{'taxonomy': ['k__a', 'p__b']},
+             {'taxonomy': ['k__a', 'p__c']},
+             {'taxonomy': ['k__a', 'p__c']}],
+            [{'barcode': 'aatt'},
+             {'barcode': 'ttgg'},
+             {'barcode': 'aatt'}])
+        bin_f = lambda id_, x: x['barcode']
+        collapsed = dt_rich.collapse(
+            bin_f, norm=False, min_group_size=1,
+            axis='sample').sort(axis='sample')
+        collapsed.to_hdf5(h5, 'tests')
+        h5.close()
+
+        h5 = h5py.File(fname, 'r')
+        self.assertIn('observation', h5)
+        self.assertIn('sample', h5)
+        self.assertEqual(sorted(h5.attrs.keys()), sorted(['id', 'type',
+                                                          'format-url',
+                                                          'format-version',
+                                                          'generated-by',
+                                                          'creation-date',
+                                                          'shape', 'nnz']))
+
+        obs = Table.from_hdf5(h5)
+        exp = Table(
+            np.array([[12, 6], [18, 9], [24, 12]]),
+            ['1', '2', '3'], ['aatt', 'ttgg'],
+            [{'taxonomy': ['k__a', 'p__b']},
+             {'taxonomy': ['k__a', 'p__c']},
+             {'taxonomy': ['k__a', 'p__c']}],
+            [{'collapsed_ids': ['a', 'c']},
+             {'collapsed_ids': ['b']}])
+        self.assertEqual(obs, exp)
+
     def test_from_tsv(self):
         tab1_fh = StringIO(otu_table1)
         sparse_rich = Table.from_tsv(tab1_fh, None, None,


### PR DESCRIPTION
Fixes #503

Instead of storing the original metadata, it creates a new category called `collapsed_ids` and stores a list of original ids.
