### PR TITLE
BUG: Remove misleading error message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ BIOM-Format ChangeLog
 biom 2.1.2-dev
 --------------
 
+Bug fixes:
+
+* Improve error message when trying to load an HDF5 file without h5py being
+    installed.
 
 biom 2.1.2
 ----------

--- a/biom/util.py
+++ b/biom/util.py
@@ -411,12 +411,27 @@ def biom_open(fp, permission='U'):
     qiime_open. QIIME is a GPL project, but we obtained permission from the
     authors of this function to port it to the BIOM Format project (and keep it
     under BIOM's BSD license).
+
+    Raises
+    ------
+    RuntimeError
+        If the user tries to parse an HDF5 file without having h5py installed.
+
     """
     if permission not in ['r', 'w', 'U', 'rb', 'wb']:
         raise IOError("Unknown mode: %s" % permission)
 
     opener = open
     mode = permission
+
+    # don't try to open an HDF5 file if H5PY is not installed, this can only
+    # happen if we are reading a file
+    if mode in {'r', 'rb', 'U'}:
+        with open(fp, 'rb') as f:
+            # from the HDF5 documentation about format signature
+            if f.read(8) == '\x89HDF\r\n\x1a\n' and not HAVE_H5PY:
+                raise RuntimeError("h5py is not installed, cannot parse HDF5 "
+                                   "BIOM file")
 
     if HAVE_H5PY:
         if mode in ['U', 'r', 'rb'] and h5py.is_hdf5(fp):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -271,6 +271,12 @@ class UtilTests(TestCase):
 
         remove(get_data_path('test_writing.biom'))
 
+    @npt.dec.skipif(HAVE_H5PY, msg='Can only be tested without H5PY')
+    def test_biom_open_hdf5_no_h5py(self):
+        with self.assertRaises(RuntimeError):
+            with biom_open(get_data_path('test.biom')) as f:
+                pass
+
     def test_biom_open_json(self):
         with biom_open(get_data_path('test.json')) as f:
             self.assertTrue(isinstance(f, file))


### PR DESCRIPTION
If the user tried to load an HDF5 file but H5PY was not available in the 
installation, a misleading error message would come up, this has been fixed
and an extra test case has been added.

Fixes #584