### PR TITLE
Issue 599

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ BIOM-Format ChangeLog
 biom 2.1.3-dev
 --------------
 
+Bug fixes:
+
+* `Table.update_ids` was not updating the internal ID lookup caches, issue #599
 
 biom 2.1.3
 ----------

--- a/biom/table.py
+++ b/biom/table.py
@@ -932,6 +932,8 @@ class Table(object):
         else:
             result._observation_ids = updated_ids
 
+        result._index_ids()
+
         # check for errors (specifically, we want to esnsure that duplicate
         # ids haven't been introduced)
         errcheck(result)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1434,6 +1434,16 @@ class SparseTableTests(TestCase):
         obs = self.st1.update_ids(id_map, axis='observation', inplace=True)
         npt.assert_equal(self.st1._observation_ids, np.array(['41', '42']))
 
+    def test_update_ids_cache_bug(self):
+        obs = self.st1.update_ids({'1': 'x', '2': 'y'}, axis='observation',
+                                  inplace=False)
+        exp_index = {'x': 0, 'y': 1}
+        self.assertEqual(obs._obs_index, exp_index)
+
+        obs = self.st1.update_ids({'a': 'x', 'b': 'y'}, inplace=False)
+        exp_index = {'x': 0, 'y': 1}
+        self.assertEqual(obs._sample_index, exp_index)
+
     def test_sort_order(self):
         """sorts tables by arbitrary order"""
         # sort by observations arbitrary order


### PR DESCRIPTION
Fixes #599. `update_ids` was not updating the internal ID caches. These are now rest.

I looked at adding this to `errcheck`, but I think that is overboard as `update_ids` is the only place that the IDs can get out of sync with the cache. 