### PR TITLE
591

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ script:
   # we can only validate the tables if we have H5PY
   - if [ ${USE_H5PY} ]; then for table in examples/*hdf5.biom; do echo ${table}; biom validate-table -i ${table}; done; fi
   # validate JSON formatted tables
-  - for table in examples/*table.biom; do echo ${table}; biom validate-table -i ${table} --is-json; done;
+  - for table in examples/*table.biom; do echo ${table}; biom validate-table -i ${table}; done;
 after_success:
   - coveralls

--- a/biom/commands/table_validator.py
+++ b/biom/commands/table_validator.py
@@ -44,9 +44,6 @@ class TableValidator(Command):
         CommandIn(Name='table', DataType=object,
                   Description='the input BIOM JSON object (e.g., the output '
                   'of json.load)', Required=True),
-        CommandIn(Name='is_json', DataType=bool,
-                  Description='the input type',
-                  Required=False, Default=False),
         CommandIn(Name='format_version', DataType=str,
                   Description='the specific format version to validate '
                   'against', Required=False, Default=None),
@@ -73,8 +70,6 @@ class TableValidator(Command):
     HDF5FormatVersions = set([(2, 0), (2, 0, 0), (2, 1), (2, 1, 0)])
 
     def run(self, **kwargs):
-        # We can't trust kwargs['is_json'] because that's determined
-        # before any parsing happens...
         is_json = not is_hdf5_file(kwargs['table'])
 
         if kwargs['format_version'] in [None, 'None']:

--- a/biom/interfaces/html/config/validate_table.py
+++ b/biom/interfaces/html/config/validate_table.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2011-2013, The BIOM Format Development Team.
 #
@@ -16,7 +16,8 @@ from biom.interfaces.html.input_handler import load_json_document
 
 __author__ = "Evan Bolyen"
 __copyright__ = "Copyright 2011-2013, The BIOM Format Development Team"
-__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald"]
+__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald",
+               "Jorge Cañardo Alastuey"]
 __license__ = "BSD"
 __url__ = "http://biom-format.org"
 __maintainer__ = "Evan Bolyen"
@@ -46,8 +47,6 @@ inputs = [
     HTMLInputOption(Parameter=cmd_in_lookup('format_version')),
 
     HTMLInputOption(Parameter=cmd_in_lookup('detailed_report'), Type=bool),
-
-    HTMLInputOption(Parameter=cmd_in_lookup('is_json'), Type=bool)
 ]
 
 outputs = [

--- a/biom/interfaces/optparse/config/validate_table.py
+++ b/biom/interfaces/optparse/config/validate_table.py
@@ -16,7 +16,6 @@ from pyqi.core.command import (make_command_in_collection_lookup_f,
                                make_command_out_collection_lookup_f)
 from pyqi.core.interfaces.optparse.output_handler import print_list_of_strings
 from biom.commands.table_validator import CommandConstructor
-from biom.interfaces.optparse.input_handler import load_hdf5_or_json
 
 __author__ = "Jai Ram Rideout"
 __copyright__ = "Copyright 2011-2013, The BIOM Format Development Team"

--- a/biom/interfaces/optparse/config/validate_table.py
+++ b/biom/interfaces/optparse/config/validate_table.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*
 # ----------------------------------------------------------------------------
 # Copyright (c) 2011-2013, The BIOM Format Development Team.
 #
@@ -19,7 +19,7 @@ from biom.commands.table_validator import CommandConstructor
 
 __author__ = "Jai Ram Rideout"
 __copyright__ = "Copyright 2011-2013, The BIOM Format Development Team"
-__credits__ = ["Jai Ram Rideout", "Daniel McDonald"]
+__credits__ = ["Jai Ram Rideout", "Daniel McDonald", "Jorge Cañardo Alastuey"]
 __license__ = "BSD"
 __url__ = "http://biom-format.org"
 __maintainer__ = "Jai Ram Rideout"
@@ -51,9 +51,6 @@ inputs = [
                    Name='input-fp',
                    Help='the input filepath to validate against the BIOM '
                    'format specification'),
-    OptparseOption(Parameter=cmd_in_lookup('is_json'),
-                   Type=None,
-                   Action='store_true'),
     OptparseOption(Parameter=cmd_in_lookup('format_version'), ShortName='f'),
 
     OptparseOption(Parameter=cmd_in_lookup('detailed_report'), Type=None,

--- a/tests/test_commands/test_table_validator.py
+++ b/tests/test_commands/test_table_validator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2011-2013, The BIOM Format Development Team.
 #
@@ -10,7 +10,8 @@
 
 __author__ = "Jai Ram Rideout"
 __copyright__ = "Copyright 2011-2013, The BIOM Format Development Team"
-__credits__ = ["Jai Ram Rideout", "Daniel McDonald"]
+__credits__ = ["Jai Ram Rideout", "Daniel McDonald",
+               "Jorge Cañardo Alastuey"]
 __license__ = "BSD"
 __url__ = "http://biom-format.org"
 __maintainer__ = "Jai Ram Rideout"
@@ -57,10 +58,10 @@ class TableValidatorTests(TestCase):
     @npt.dec.skipif(HAVE_H5PY == False, msg='H5PY is not installed')
     def test_valid_hdf5_metadata_v210(self):
         exp = {'valid_table': True, 'report_lines': []}
-        obs = self.cmd(table=self.hdf5_file_valid, is_json=False,
+        obs = self.cmd(table=self.hdf5_file_valid,
                        format_version='2.1')
         self.assertEqual(obs, exp)
-        obs = self.cmd(table=self.hdf5_file_valid_md, is_json=False,
+        obs = self.cmd(table=self.hdf5_file_valid_md,
                        format_version='2.1')
         self.assertEqual(obs, exp)
 
@@ -74,7 +75,7 @@ class TableValidatorTests(TestCase):
         exp = {'valid_table': True,
                'report_lines': []}
 
-        obs = self.cmd(table=self.hdf5_file_valid, is_json=False)
+        obs = self.cmd(table=self.hdf5_file_valid)
         self.assertEqual(obs, exp)
 
     @npt.dec.skipif(HAVE_H5PY == False, msg='H5PY is not installed')
@@ -90,7 +91,7 @@ class TableValidatorTests(TestCase):
         del f.attrs['creation-date']
 
         f.close()
-        obs = self.cmd(table='invalid.hdf5', is_json=False)
+        obs = self.cmd(table='invalid.hdf5')
         self.assertEqual(obs, exp)
 
     def test_valid(self):
@@ -102,7 +103,7 @@ class TableValidatorTests(TestCase):
         f.close()
         self.to_remove.append('valid_test1')
 
-        obs = self.cmd(table='valid_test1', is_json=True)
+        obs = self.cmd(table='valid_test1')
         self.assertEqual(obs, exp)
 
         f = open('valid_test2', 'w')
@@ -110,7 +111,7 @@ class TableValidatorTests(TestCase):
         f.close()
         self.to_remove.append('valid_test2')
 
-        obs = self.cmd(table='valid_test2', is_json=True)
+        obs = self.cmd(table='valid_test2')
         self.assertEqual(obs, exp)
 
         # Soldier, report!!
@@ -119,7 +120,7 @@ class TableValidatorTests(TestCase):
         f.close()
         self.to_remove.append('valid_test3')
 
-        obs = self.cmd(table='valid_test3', detailed_report=True, is_json=True)
+        obs = self.cmd(table='valid_test3', detailed_report=True)
         self.assertTrue(obs['valid_table'])
         self.assertTrue(len(obs['report_lines']) > 0)
 
@@ -133,7 +134,7 @@ class TableValidatorTests(TestCase):
         f.close()
         self.to_remove.append('invalid_test1')
 
-        obs = self.cmd(table='invalid_test1', is_json=True)
+        obs = self.cmd(table='invalid_test1')
         self.assertEqual(obs, exp)
 
         self.rich_dense_otu['shape'][1] = 42
@@ -147,7 +148,7 @@ class TableValidatorTests(TestCase):
         f.close()
         self.to_remove.append('invalid_test2')
 
-        obs = self.cmd(table='invalid_test2', is_json=True)
+        obs = self.cmd(table='invalid_test2')
         self.assertEqual(obs, exp)
 
     def test_valid_format_url(self):

--- a/tests/test_commands/test_table_validator.py
+++ b/tests/test_commands/test_table_validator.py
@@ -21,7 +21,6 @@ import json
 from unittest import TestCase, main
 from shutil import copy
 
-import numpy as np
 import numpy.testing as npt
 
 from biom.commands.table_validator import TableValidator


### PR DESCRIPTION
We were already ignoring `--is-json`, now remove it. Note that this is not backwards compatible, as trying to validate a table using that option will raise an error: `biom validate-table: error: no such option: --is-json`.