### PR TITLE
ENH/TST: custom parsers and formatters for hdf5 metadata

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ BIOM-Format ChangeLog
 biom 2.1.3-dev
 --------------
 
+Changes:
+
+* `Table.to_hdf5` and `Table.from_hdf5` now support custom parsers and
+    formatters, see issue #608
+
 Bug fixes:
 
 * `Table.update_ids` was not updating the internal ID lookup caches, issue #599

--- a/biom/table.py
+++ b/biom/table.py
@@ -3357,10 +3357,14 @@ dataset of int32
             Specify custom formatting functions for metadata fields. This dict
             is expected to be {'metadata_field': function}, where the function
             signature is (h5py.Group, str, dict, bool) corresponding to the
-            specific group the metadata dataset will be associated with, the
-            category being operated on, the metadata for the entire axis being
-            operated on, and whether to enable compression on the dataset.
-            Anything returned by this function is ignored.
+            specific HDF5 group the metadata dataset will be associated with,
+            the category being operated on, the metadata for the entire axis
+            being operated on, and whether to enable compression on the
+            dataset.  Anything returned by this function is ignored.
+
+        Notes
+        -----
+        This method does not return anything and operates in place on h5grp.
 
         See Also
         --------

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -299,7 +299,6 @@ class TableTests(TestCase):
         self.assertTrue(t._sample_metadata is None)
         self.assertTrue(t._observation_metadata is None)
 
-
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_from_hdf5_custom_parsers(self):
         def parser(item):
@@ -315,7 +314,6 @@ class TableTests(TestCase):
 
         for m in t.metadata():
             self.assertIn(m['BODY_SITE'], ('GUT', 'SKIN'))
-
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_from_hdf5(self):
@@ -602,7 +600,6 @@ class TableTests(TestCase):
             data = np.array([m[category].upper() for m in md])
             grp.create_dataset(name, shape=data.shape, dtype=H5PY_VLEN_STR,
                                data=data, compression=compression)
-
 
         fname = mktemp()
         self.to_remove.append(fname)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy.sparse import lil_matrix, csr_matrix, csc_matrix
 
 from biom.exception import UnknownAxisError, UnknownIDError, TableException
-from biom.util import unzip, HAVE_H5PY
+from biom.util import unzip, HAVE_H5PY, H5PY_VLEN_STR
 from biom.table import (Table, prefer_self, index_list, list_nparray_to_sparse,
                         list_dict_to_sparse, dict_to_sparse,
                         coo_arrays_to_sparse, list_list_to_sparse,
@@ -299,6 +299,24 @@ class TableTests(TestCase):
         self.assertTrue(t._sample_metadata is None)
         self.assertTrue(t._observation_metadata is None)
 
+
+    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
+    def test_from_hdf5_custom_parsers(self):
+        def parser(item):
+            return item.upper()
+        parse_fs = {'BODY_SITE': parser}
+
+        cwd = os.getcwd()
+        if '/' in __file__:
+            os.chdir(__file__.rsplit('/', 1)[0])
+        t = Table.from_hdf5(h5py.File('test_data/test.biom'),
+                            parse_fs=parse_fs)
+        os.chdir(cwd)
+
+        for m in t.metadata():
+            self.assertIn(m['BODY_SITE'], ('GUT', 'SKIN'))
+
+
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_from_hdf5(self):
         """Parse a hdf5 formatted BIOM table"""
@@ -570,6 +588,42 @@ class TableTests(TestCase):
              {'barcode': 'aatt'}])
         with self.assertRaises(TypeError):
             t.to_hdf5(h5, 'tests')
+
+    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
+    def test_to_hdf5_custom_formatters(self):
+        self.st_rich = Table(self.vals,
+                             ['1', '2'], ['a', 'b'],
+                             [{'taxonomy': ['k__a', 'p__b']},
+                              {'taxonomy': ['k__a', 'p__c']}],
+                             [{'barcode': 'aatt'}, {'barcode': 'ttgg'}])
+
+        def bc_formatter(grp, category, md, compression):
+            name = 'metadata/%s' % category
+            data = np.array([m[category].upper() for m in md])
+            grp.create_dataset(name, shape=data.shape, dtype=H5PY_VLEN_STR,
+                               data=data, compression=compression)
+
+
+        fname = mktemp()
+        self.to_remove.append(fname)
+        h5 = h5py.File(fname, 'w')
+        self.st_rich.to_hdf5(h5, 'tests', format_fs={'barcode': bc_formatter})
+        h5.close()
+
+        h5 = h5py.File(fname, 'r')
+        self.assertIn('observation', h5)
+        self.assertIn('sample', h5)
+        self.assertEqual(sorted(h5.attrs.keys()), sorted(['id', 'type',
+                                                          'format-url',
+                                                          'format-version',
+                                                          'generated-by',
+                                                          'creation-date',
+                                                          'shape', 'nnz']))
+
+        obs = Table.from_hdf5(h5)
+        for m1, m2 in zip(obs.metadata(), self.st_rich.metadata()):
+            self.assertNotEqual(m1['barcode'], m2['barcode'])
+            self.assertEqual(m1['barcode'].lower(), m2['barcode'])
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_to_hdf5(self):


### PR DESCRIPTION
Fixes #608 

This change allows for custom parsers and formatters. I don't think that it is sustainable adding in more hardcoded parsing types. Within picrust, we'll be able to just define a parser/formatter that serializes the nested lists in a few of the metadata types into json. 