### PR TITLE
BUG/ENH: Check for filesize when reading file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Bug fixes:
 * `Table.update_ids` was not updating the internal ID lookup caches, issue #599
 * `Table.collapse`, under `one_to_many` was not constructing the resulting
     matrix properly, issue #606
+* Improve error message when trying to load an empty file, issue #614.
 
 biom 2.1.3
 ----------

--- a/biom/util.py
+++ b/biom/util.py
@@ -418,6 +418,8 @@ def biom_open(fp, permission='U'):
     ------
     RuntimeError
         If the user tries to parse an HDF5 file without having h5py installed.
+    ValueError
+        If the user tries to read an empty file.
 
     """
     if permission not in ['r', 'w', 'U', 'rb', 'wb']:
@@ -429,6 +431,9 @@ def biom_open(fp, permission='U'):
     # don't try to open an HDF5 file if H5PY is not installed, this can only
     # happen if we are reading a file
     if mode in {'r', 'rb', 'U'}:
+        if os.path.getsize(fp) == 0:
+            raise ValueError("The file '%s' is empty and can't be parsed" % fp)
+
         if is_hdf5_file(fp) and not HAVE_H5PY:
             raise RuntimeError("h5py is not installed, cannot parse HDF5 "
                                "BIOM file")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -271,6 +271,12 @@ class UtilTests(TestCase):
 
         remove(get_data_path('test_writing.biom'))
 
+    def test_biom_open_empty(self):
+        with self.assertRaises(ValueError) as e:
+            with biom_open(get_data_path('no-contents.biom'), 'r') as f:
+                pass
+        self.assertTrue("is empty and can't be parsed" in str(e.exception))
+
     @npt.dec.skipif(HAVE_H5PY, msg='Can only be tested without H5PY')
     def test_biom_open_hdf5_no_h5py(self):
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Add an explicit check to verify the passed file is not empty.

Fixes #614