### PR TITLE
BLD: test against py3.4 and py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 # Modified from https://github.com/biocore/scikit-bio/
 language: python
-python:
-  - "2.7"
 env:
-  - NUMPY_VERSION=1.7
-  - NUMPY_VERSION=1.8
-  - NUMPY_VERSION=1.8 USE_H5PY=True
-  - NUMPY_VERSION=1.8 USE_CYTHON=True
-  - NUMPY_VERSION=1.7 USE_H5PY=True
+  - PYTHON_VERSION=2.7 USE_H5PY=True
+  - PYTHON_VERSION=2.7 USE_CYTHON=True
+  - PYTHON_VERSION=3.4 USE_H5PY=True
+  - PYTHON_VERSION=3.4 USE_CYTHON=True
+  - PYTHON_VERSION=3.5 USE_H5PY=True
+  - PYTHON_VERSION=3.5 USE_CYTHON=True
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -16,7 +15,7 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy=$NUMPY_VERSION scipy nose pep8 Sphinx coverage
+  - conda create --yes -n env_name python=$PYTHON_VERSION pip numpy scipy nose pep8 Sphinx coverage
   - if [ ${USE_CYTHON} ]; then conda install --yes -n env_name cython; fi
   - if [ ${USE_H5PY} ]; then conda install --yes -n env_name h5py>=2.2.0; fi
   - source activate env_name


### PR DESCRIPTION
Enumerates python versions to test, all with and without h5py and cython. Removed the numpy version checks as it wasn't clear if they're necessary.