### PR TITLE
Update `future` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if USE_CYTHON:
     from Cython.Build import cythonize
     extensions = cythonize(extensions)
 
-install_requires = ["click", "numpy >= 1.3.0", "future >= 0.14.3",
+install_requires = ["click", "numpy >= 1.3.0", "future >= 0.15.0",
                     "scipy >= 0.13.0"]
 # HACK: for backward-compatibility with QIIME 1.9.x, pyqi must be installed.
 # pyqi is not used anymore in this project.


### PR DESCRIPTION
biom_format is using string_type from the future module, but this is included in version 0.15.0.

https://github.com/PythonCharmers/python-future/commit/3b9c2115aa38b516c82ff6bf370eeac31b9b6a62