### PR TITLE
Adds context_settings to click.group

### DIFF
--- a/biom/cli/__init__.py
+++ b/biom/cli/__init__.py
@@ -14,7 +14,7 @@ import click
 import biom
 
 
-@click.group()
+@click.group(context_settings=dict(help_option_names=['-h', '--help']))
 @click.version_option(version=biom.__version__)
 def cli():
     pass


### PR DESCRIPTION
Allows `biom -h`, `biom head -h`, etc.