### PR TITLE
Rapid subset

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@ biom 2.1.5-dev
 
 Changes since biom 2.1.5 go here.
 
+New Features:
+
+* `Table.from_hdf5` now supports a rapid subset in the event that metadata is
+   not needed. In benchmarking against the Earth Microbiome Project BIOM table,
+   the reduction in runtime was multiple orders of magnitude while additionally
+   preserving substantial memory. 
+
 biom 2.1.5
 ----------
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -3287,17 +3287,17 @@ html
                 samp_ids = axis_ids[to_keep]
                 shape = (len(obs_ids), len(to_keep))
                 mat = csc_matrix((data, indices, indptr), shape=shape)
-                mat_nz = np.unique(mat.nonzero()[0])  # nz rows
-                obs_ids = obs_ids[mat_nz]
-                mat = mat[mat_nz]
+                #mat_nz = np.unique(mat.nonzero()[0])  # nz rows
+                #obs_ids = obs_ids[mat_nz]
+                #mat = mat[mat_nz]
             else:
                 samp_ids = h5grp['sample/ids'][:]
                 obs_ids = axis_ids[to_keep]
                 shape = (len(to_keep), len(samp_ids))
                 mat = csr_matrix((data, indices, indptr), shape=shape)
-                mat_nz = np.unique(mat.nonzero()[1])  # nz columns
-                samp_ids = samp_ids[mat_nz]
-                mat = mat[:, mat_nz]
+                #mat_nz = np.unique(mat.nonzero()[1])  # nz columns
+                #samp_ids = samp_ids[mat_nz]
+                #mat = mat[:, mat_nz]
 
             return Table(mat, obs_ids, samp_ids)
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -3341,17 +3341,11 @@ html
                 samp_ids = axis_ids[to_keep]
                 shape = (len(obs_ids), len(to_keep))
                 mat = csc_matrix((data, indices, indptr), shape=shape)
-                #mat_nz = np.unique(mat.nonzero()[0])  # nz rows
-                #obs_ids = obs_ids[mat_nz]
-                #mat = mat[mat_nz]
             else:
                 samp_ids = h5grp['sample/ids'][:]
                 obs_ids = axis_ids[to_keep]
                 shape = (len(to_keep), len(samp_ids))
                 mat = csr_matrix((data, indices, indptr), shape=shape)
-                #mat_nz = np.unique(mat.nonzero()[1])  # nz columns
-                #samp_ids = samp_ids[mat_nz]
-                #mat = mat[:, mat_nz]
 
             return Table(mat, obs_ids, samp_ids)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -453,6 +453,32 @@ class TableTests(TestCase):
         npt.assert_equal(list(t.iter_data(axis="observation")), exp)
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
+    def test_from_hdf5_sample_subset_no_metadata(self):
+        """Parse a sample subset of a hdf5 formatted BIOM table"""
+        samples = [b'Sample2', b'Sample4', b'Sample6']
+
+        cwd = os.getcwd()
+        if '/' in __file__:
+            os.chdir(__file__.rsplit('/', 1)[0])
+        t = Table.from_hdf5(h5py.File('test_data/test.biom'), ids=samples,
+                            subset_with_metadata=False)
+        os.chdir(cwd)
+
+        npt.assert_equal(t.ids(), [b'Sample2', b'Sample4', b'Sample6'])
+        npt.assert_equal(t.ids(axis='observation'),
+                         [b'GG_OTU_2', b'GG_OTU_3', b'GG_OTU_4', b'GG_OTU_5'])
+        exp_obs_md = None
+        self.assertEqual(t._observation_metadata, exp_obs_md)
+        exp_samp_md = None
+        self.assertEqual(t._sample_metadata, exp_samp_md)
+
+        exp = [np.array([1., 2., 1.]),
+               np.array([0., 4., 2.]),
+               np.array([1., 0., 1.]),
+               np.array([1., 0., 0.])]
+        npt.assert_equal(list(t.iter_data(axis='observation')), exp)
+
+    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_from_hdf5_sample_subset(self):
         """Parse a sample subset of a hdf5 formatted BIOM table"""
         samples = [u'Sample2', u'Sample4', u'Sample6']
@@ -514,6 +540,34 @@ class TableTests(TestCase):
                np.array([0., 4., 2.]),
                np.array([1., 0., 1.]),
                np.array([1., 0., 0.])]
+        npt.assert_equal(list(t.iter_data(axis='observation')), exp)
+
+    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
+    def test_from_hdf5_observation_subset_no_metadata(self):
+        """Parse a observation subset of a hdf5 formatted BIOM table"""
+        observations = [b'GG_OTU_1', b'GG_OTU_3', b'GG_OTU_5']
+
+        cwd = os.getcwd()
+        if '/' in __file__:
+            os.chdir(__file__.rsplit('/', 1)[0])
+        t = Table.from_hdf5(h5py.File('test_data/test.biom'),
+                            ids=observations, axis='observation',
+                            subset_with_metadata=False)
+        os.chdir(cwd)
+
+        npt.assert_equal(t.ids(), [b'Sample2', b'Sample3', b'Sample4',
+                                   b'Sample6'])
+        npt.assert_equal(t.ids(axis='observation'),
+                         [b'GG_OTU_1', b'GG_OTU_3', b'GG_OTU_5'])
+        exp_obs_md = None
+        self.assertEqual(t._observation_metadata, exp_obs_md)
+
+        exp_samp_md = None
+        self.assertEqual(t._sample_metadata, exp_samp_md)
+
+        exp = [np.array([0., 1., 0., 0.]),
+               np.array([0., 1., 4., 2.]),
+               np.array([1., 1., 0., 0.])]
         npt.assert_equal(list(t.iter_data(axis='observation')), exp)
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -466,13 +466,15 @@ class TableTests(TestCase):
 
         npt.assert_equal(t.ids(), [b'Sample2', b'Sample4', b'Sample6'])
         npt.assert_equal(t.ids(axis='observation'),
-                         [b'GG_OTU_2', b'GG_OTU_3', b'GG_OTU_4', b'GG_OTU_5'])
+                         [b'GG_OTU_1', b'GG_OTU_2', b'GG_OTU_3', b'GG_OTU_4',
+                          b'GG_OTU_5'])
         exp_obs_md = None
         self.assertEqual(t._observation_metadata, exp_obs_md)
         exp_samp_md = None
         self.assertEqual(t._sample_metadata, exp_samp_md)
 
-        exp = [np.array([1., 2., 1.]),
+        exp = [np.array([0, 0, 0]),
+               np.array([1., 2., 1.]),
                np.array([0., 4., 2.]),
                np.array([1., 0., 1.]),
                np.array([1., 0., 0.])]
@@ -555,8 +557,8 @@ class TableTests(TestCase):
                             subset_with_metadata=False)
         os.chdir(cwd)
 
-        npt.assert_equal(t.ids(), [b'Sample2', b'Sample3', b'Sample4',
-                                   b'Sample6'])
+        npt.assert_equal(t.ids(), [b'Sample1', b'Sample2', b'Sample3',
+                                   b'Sample4', b'Sample5', b'Sample6'])
         npt.assert_equal(t.ids(axis='observation'),
                          [b'GG_OTU_1', b'GG_OTU_3', b'GG_OTU_5'])
         exp_obs_md = None
@@ -565,9 +567,9 @@ class TableTests(TestCase):
         exp_samp_md = None
         self.assertEqual(t._sample_metadata, exp_samp_md)
 
-        exp = [np.array([0., 1., 0., 0.]),
-               np.array([0., 1., 4., 2.]),
-               np.array([1., 1., 0., 0.])]
+        exp = [np.array([0, 0., 1., 0., 0, 0.]),
+               np.array([0, 0., 1., 4., 0, 2.]),
+               np.array([0, 1., 1., 0., 0, 0.])]
         npt.assert_equal(list(t.iter_data(axis='observation')), exp)
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')


### PR DESCRIPTION
@josenavas, possible for a review on this? Asking as I believe you wrote the normal subset method. Basically, the subset kills you when handling metadata, which is fine for one-off runs, but I need to do repeated subsetting for EMP in the context of the block decomposition for unifrac. See [here](https://gist.github.com/wasade/60db4059e3b7e42bb648db1d10ef72d6) for the motivator, which I'd like to get running tomorrow on EMP oref. This PR doesn't block, but it's necessary for this approach to be feasible