### PR TITLE
add correct numpy c include path (fixes #705)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,14 @@ classifiers = [s.strip() for s in classes.split('\n') if s]
 USE_CYTHON = os.environ.get('USE_CYTHON', False)
 ext = '.pyx' if USE_CYTHON else '.c'
 extensions = [Extension("biom._filter",
-                        ["biom/_filter" + ext]),
+                        ["biom/_filter" + ext],
+                        include_dirs=[np.get_include()]),
               Extension("biom._transform",
-                        ["biom/_transform" + ext]),
+                        ["biom/_transform" + ext],
+                        include_dirs=[np.get_include()]),
               Extension("biom._subsample",
-                        ["biom/_subsample" + ext])]
+                        ["biom/_subsample" + ext],
+                        include_dirs=[np.get_include()])]
 
 if USE_CYTHON:
     from Cython.Build import cythonize


### PR DESCRIPTION
Cython does not automagically add a `-I<pathtonumpyincludes>` option to the compiler directives. Compiling the modules therefore only worked if there was a numpy version installed to system/default directories. If multiple versions where installed, compilation always used the headers from the system/default installation.