### PR TITLE
WIP: to pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n env_name python=$PYTHON_VERSION pip click numpy scipy nose pep8 flake8 coverage future
+  - conda create --yes -n env_name python=$PYTHON_VERSION pip click numpy scipy nose pep8 flake8 coverage future pandas
   - if [ ${USE_CYTHON} ]; then conda install --yes -n env_name cython; fi
   - if [ ${USE_H5PY} ]; then conda install --yes -n env_name h5py>=2.2.0; fi
   - if [ ${PYTHON_VERSION} = "2.7" ]; then conda install --yes -n env_name Sphinx=1.2.2; fi

--- a/biom/table.py
+++ b/biom/table.py
@@ -522,11 +522,12 @@ class Table(object):
         return self._data
 
     def to_pandas(self):
-        """
+        """ Converts biom table into 3 pandas dataframes.
+
         Returns
         ----------
         counts : pd.SparseDataFrame
-            Pandas representation of counts
+            Pandas representation of table values (i.e. counts)
         sample_metadata : pd.DataFrame
             Pandas representation of the sample metadata
         observation_metadata : pd.DataFrame
@@ -536,7 +537,7 @@ class Table(object):
         ----
         This assumes that the keys across the metadata fields are consistent.
         For example, if the first observation has taxonomy, it is assumed that
-        all of the features also have taxonomy.
+        all of the observations also have taxonomy.
         """
         # Double check to see if pandas is installed properly
         try:

--- a/biom/table.py
+++ b/biom/table.py
@@ -547,7 +547,8 @@ class Table(object):
 
         # Extract count data
         m = self.matrix_data
-        data = [pd.SparseSeries(np.squeeze(row.toarray())) for row in self.matrix_data]
+        data = [pd.SparseSeries(np.squeeze(row.toarray()))
+                for row in self.matrix_data]
         counts = pd.SparseDataFrame(data, index=self.ids('observation'),
                                     columns=self.ids('sample'))
 

--- a/biom/util.py
+++ b/biom/util.py
@@ -513,3 +513,8 @@ def is_hdf5_file(fp):
     with open(fp, 'rb') as f:
         # from the HDF5 documentation about format signature
         return f.read(8) == b'\x89HDF\r\n\x1a\n'
+
+
+def pad_taxa(taxa_list):
+    taxa_blank = ['k__', 'p__', 'c__', 'o__', 'f__', 'g__', 's__']
+    return taxa_list + taxa_blank[-(7-len(taxa_list)):]

--- a/biom/util.py
+++ b/biom/util.py
@@ -36,6 +36,12 @@ except ImportError:
     H5PY_VLEN_STR = None
     H5PY_VLEN_UNICODE = None
 
+try:
+    import pandas
+    HAVE_PD = True
+except ImportError:
+    HAVE_PD = False
+
 from numpy import mean, median, min, max
 
 __author__ = "Daniel McDonald"
@@ -513,8 +519,3 @@ def is_hdf5_file(fp):
     with open(fp, 'rb') as f:
         # from the HDF5 documentation about format signature
         return f.read(8) == b'\x89HDF\r\n\x1a\n'
-
-
-def pad_taxa(taxa_list):
-    taxa_blank = ['k__', 'p__', 'c__', 'o__', 'f__', 'g__', 's__']
-    return taxa_list + taxa_blank[-(7-len(taxa_list)):]

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ if USE_CYTHON:
     extensions = cythonize(extensions)
 
 install_requires = ["click", "numpy >= 1.3.0", "future >= 0.15.0",
-                    "scipy >= 0.13.0"]
+                    "scipy >= 0.13.0", "pandas"]
 # HACK: for backward-compatibility with QIIME 1.9.x, pyqi must be installed.
 # pyqi is not used anymore in this project.
 if sys.version_info[0] < 3:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -951,10 +951,11 @@ class TableTests(TestCase):
 
     def test_metadata_sample_id(self):
         """returns the sample metadata for a given id"""
+
         self.assertEqual({'barcode': 'aatt'},
-                         self.st_rich.metadata('a'))
+                         self.st_rich.metadata('a').to_dict())
         self.assertEqual({'barcode': 'ttgg'},
-                         self.st_rich.metadata('b'))
+                         self.st_rich.metadata('b').to_dict())
 
         with self.assertRaises(UnknownIDError):
             self.st_rich.metadata(3, 'sample')
@@ -962,16 +963,17 @@ class TableTests(TestCase):
     def test_metadata_sample(self):
         """Return the sample metadata"""
         obs = self.st_rich.metadata()
-        exp = [{'barcode': 'aatt'}, {'barcode': 'ttgg'}]
-        for o, e in zip(obs, exp):
-            self.assertDictEqual(o, e)
+        exp = pd.DataFrame({'barcode': ['aatt', 'ttgg']},
+                            index=['a', 'b'])
+        pdt.assert_frame_equal(exp, obs)
+
 
     def test_metadata_observation_id(self):
         """returns the observation metadata for a given id"""
         self.assertEqual({'taxonomy': ['k__a', 'p__b']},
-                         self.st_rich.metadata('1', 'observation'))
+                         self.st_rich.metadata('1', 'observation').to_dict())
         self.assertEqual({'taxonomy': ['k__a', 'p__c']},
-                         self.st_rich.metadata('2', 'observation'))
+                         self.st_rich.metadata('2', 'observation').to_dict())
 
         with self.assertRaises(UnknownIDError):
             self.simple_derived.metadata('3', 'observation')
@@ -979,9 +981,10 @@ class TableTests(TestCase):
     def test_metadata_observation(self):
         """returns the observation metadata"""
         obs = self.st_rich.metadata(axis='observation')
-        exp = [{'taxonomy': ['k__a', 'p__b']}, {'taxonomy': ['k__a', 'p__c']}]
-        for o, e in zip(obs, exp):
-            self.assertDictEqual(o, e)
+        exp = pd.DataFrame({'taxonomy': [['k__a', 'p__b'],
+                                         ['k__a', 'p__c']]},
+                           index=['1', '2'])
+        pdt.assert_frame_equal(exp, obs)
 
     def test_index_invalid_input(self):
         """Correctly handles invalid input."""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -22,17 +22,22 @@ from scipy.sparse import lil_matrix, csr_matrix, csc_matrix
 
 from biom import example_table
 from biom.exception import UnknownAxisError, UnknownIDError, TableException
-from biom.util import unzip, HAVE_H5PY, H5PY_VLEN_STR
+from biom.util import unzip, HAVE_H5PY, H5PY_VLEN_STR, HAVE_PD
 from biom.table import (Table, prefer_self, index_list, list_nparray_to_sparse,
                         list_dict_to_sparse, dict_to_sparse,
                         coo_arrays_to_sparse, list_list_to_sparse,
                         nparray_to_sparse, list_sparse_to_sparse)
 from biom.parse import parse_biom_table
 from biom.err import errstate
-import pandas.util.testing as pdt
+
 
 if HAVE_H5PY:
     import h5py
+
+if HAVE_PD:
+    import pandas as pd
+    import pandas.util.testing as pdt
+
 
 __author__ = "Daniel McDonald"
 __copyright__ = "Copyright 2011-2013, The BIOM Format Development Team"
@@ -3289,6 +3294,53 @@ class SparseTableTests(TestCase):
         # Tables with some zeros explicitly defined.
         npt.assert_almost_equal(self.st7.get_table_density(), 0.75)
 
+    def test_to_pandas_pathways(self):
+        dt_rich = Table(np.array([[5, 6, 7], [8, 9, 10], [11, 12, 13]]),
+                        ['1', '2', '3'], ['a', 'b', 'c'],
+                        [{'pathways': [['a', 'bx'], ['a', 'd']]},
+                         {'pathways': [['a', 'bx'], ['a', 'c']]},
+                         {'pathways': [['a']]}],
+                        [{'barcode': 'aatt'},
+                         {'barcode': 'ttgg'},
+                         {'barcode': 'aatt'}])
+        exp_obs = pd.DataFrame(
+            {'pathways': [[['a', 'bx'], ['a', 'd']],
+                          [['a', 'bx'], ['a', 'c']],
+                          [['a']]]}, index=['1', '2', '3'])
+        exp_samp = pd.DataFrame(
+            {'barcode': ['aatt', 'ttgg', 'aatt']},
+            index=['a', 'b', 'c'])
+        exp_counts = pd.SparseDataFrame(
+            np.array([[5., 6., 7.], [8., 9., 10.], [11., 12., 13.]]),
+            index=['1', '2', '3'],
+            columns=['a', 'b', 'c'])
+
+        res_counts, res_samp, res_obs = dt_rich.to_pandas()
+        pdt.assert_frame_equal(res_counts, exp_counts)
+        pdt.assert_frame_equal(res_samp, exp_samp)
+        pdt.assert_frame_equal(res_obs, exp_obs)
+
+    @npt.dec.skipif(HAVE_PD is False, msg='pandas is not installed')
+    def test_to_pandas_taxonomy(self):
+
+        st_rich = Table(self.vals,
+                        ['1', '2'], ['a', 'b'],
+                        [{'taxonomy': ['k__a', 'p__b']},
+                         {'taxonomy': ['k__a', 'p__c']}],
+                        [{'barcode': 'aatt'}, {'barcode': 'ttgg'}])
+
+        exp_counts = pd.SparseDataFrame([[5., 6.], [7., 8.]],
+                                        index=['1', '2'],
+                                        columns=['a', 'b'])
+        exp_obs = pd.DataFrame({'taxonomy': [['k__a', 'p__b'],
+                                              ['k__a', 'p__c']]},
+                               index=['1', '2'])
+        exp_samp = pd.DataFrame({'barcode': ['aatt',  'ttgg']},
+                                index=['a', 'b'])
+        res_counts, res_samp, res_obs = st_rich.to_pandas()
+        pdt.assert_frame_equal(res_counts, exp_counts)
+        pdt.assert_frame_equal(res_samp, exp_samp)
+        pdt.assert_frame_equal(res_obs, exp_obs)
 
 class SupportTests2(TestCase):
 
@@ -3448,121 +3500,6 @@ class SupportTests2(TestCase):
         exp[1, 3] = 2
         obs = list_sparse_to_sparse(ins)
         self.assertEqual((obs != exp).sum(), 0)
-
-    def test_to_pandas_pathways(self):
-        dt_rich = Table(np.array([[5, 6, 7], [8, 9, 10], [11, 12, 13]]),
-                        ['1', '2', '3'], ['a', 'b', 'c'],
-                        [{'pathways': [['a', 'bx'], ['a', 'd']]},
-                         {'pathways': [['a', 'bx'], ['a', 'c']]},
-                         {'pathways': [['a']]}],
-                        [{'barcode': 'aatt'},
-                         {'barcode': 'ttgg'},
-                         {'barcode': 'aatt'}])
-        pass
-
-    def test_to_pandas_taxonomy(self):
-        self.st_rich = Table(self.vals,
-                             ['1', '2'], ['a', 'b'],
-                             [{'taxonomy': ['k__a', 'p__b']},
-                              {'taxonomy': ['k__a', 'p__c']}],
-                             [{'barcode': 'aatt'}, {'barcode': 'ttgg'}],
-                             )
-        pass
-
-    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
-    def test_to_pandas(self):
-        """Parse a hdf5 formatted BIOM table"""
-
-        exp_obs_md = pd.DataFrame(
-            [[u'k__Bacteria',
-              u'p__Proteobacteria',
-              u'c__Gammaproteobacteria',
-              u'o__Enterobacteriales',
-              u'f__Enterobacteriaceae',
-              u'g__Escherichia',
-              u's__'],
-             [u'k__Bacteria',
-              u'p__Cyanobacteria',
-              u'c__Nostocophycideae',
-              u'o__Nostocales',
-              u'f__Nostocaceae',
-              u'g__Dolichospermum',
-              u's__'],
-             [u'k__Archaea',
-              u'p__Euryarchaeota',
-              u'c__Methanomicrobia',
-              u'o__Methanosarcinales',
-              u'f__Methanosarcinaceae',
-              u'g__Methanosarcina',
-              u's__'],
-             [u'k__Bacteria',
-              u'p__Firmicutes',
-              u'c__Clostridia',
-              u'o__Halanaerobiales',
-              u'f__Halanaerobiaceae',
-              u'g__Halanaerobium',
-              u's__Halanaerobiumsaccharolyticum'],
-             [u'k__Bacteria',
-              u'p__Proteobacteria',
-              u'c__Gammaproteobacteria',
-              u'o__Enterobacteriales',
-              u'f__Enterobacteriaceae',
-              u'g__Escherichia',
-              u's__']],
-            columns=['kingdom', 'phylum', 'class', 'order',
-                     'family', 'genus', 'species'],
-            index=(u'GG_OTU_1', u'GG_OTU_2', u'GG_OTU_3',
-                   u'GG_OTU_4', u'GG_OTU_5')))
-
-        exp_samp_md = pd.DataFrame(
-            [[u'CATGCTGCCTCCCGTAGGAGT',
-              u'CGCTTATCGAGA',
-              u'human gut',
-              u'gut'],
-             [u'CATGCTGCCTCCCGTAGGAGT',
-              u'CATACCAGTAGC',
-              u'human gut',
-              u'gut'],
-             [u'CATGCTGCCTCCCGTAGGAGT',
-              u'CTCTCTACCTGT',
-              u'human gut',
-              u'gut'],
-             [u'CATGCTGCCTCCCGTAGGAGT',
-              u'CTCTCGGCCTGT',
-              u'human skin',
-              u'skin'],
-             [u'CATGCTGCCTCCCGTAGGAGT',
-              u'CTCTCTACCAAT',
-              u'human skin',
-              u'skin'],
-             [u'CATGCTGCCTCCCGTAGGAGT',
-              u'CTAACTACCAAT',
-              u'human skin',
-              u'skin']],
-            index=(u'Sample1', u'Sample2', u'Sample3',
-                   u'Sample4', u'Sample5', u'Sample6'),
-            columns=[u'LinkerPrimerSequence', u'BarcodeSequence',
-                     u'Description', u'BODY_SITE'])
-
-        exp_counts = pd.SparseDataFrame({
-            'GG_OTU_1': np.array([0., 0., 1., 0., 0., 0.]),
-            'GG_OTU_2': np.array([5., 1., 0., 2., 3., 1.]),
-            'GG_OTU_3': np.array([0., 0., 1., 4., 0., 2.]),
-            'GG_OTU_4': np.array([2., 1., 1., 0., 0., 1.]),
-            'GG_OTU_5': np.array([0., 1., 1., 0., 0., 0.]),
-            index=(u'Sample1', u'Sample2', u'Sample3',
-                   u'Sample4', u'Sample5', u'Sample6')}).T
-
-        cwd = os.getcwd()
-        if '/' in __file__:
-            os.chdir(__file__.rsplit('/', 1)[0])
-        t = Table.from_hdf5(h5py.File('test_data/test.biom'))
-        os.chdir(cwd)
-
-        res_counts, res_samp_md, res_obs_md = t.to_pandas()
-        self.assert_frame_equal(exp_counts, res_counts)
-        self.assert_frame_equal(exp_samp_md, res_samp_md)
-        self.assert_frame_equal(exp_obs_md, res_obs_md)
 
 
 legacy_otu_table1 = u"""# some comment goes here

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1150,19 +1150,20 @@ class TableTests(TestCase):
         t = Table(d, obs_ids, samp_ids, observation_metadata=None,
                   sample_metadata=samp_md)
         t.add_metadata(obs_md, axis='observation')
-        self.assertEqual(t._observation_metadata[0]['taxonomy'], ['A', 'B'])
-        self.assertEqual(t._observation_metadata[1]['taxonomy'], ['B', 'C'])
-        self.assertEqual(t._observation_metadata[2]['taxonomy'],
+
+        self.assertEqual(t._observation_metadata.iloc[0]['taxonomy'], ['A', 'B'])
+        self.assertEqual(t._observation_metadata.iloc[1]['taxonomy'], ['B', 'C'])
+        self.assertEqual(t._observation_metadata.iloc[2]['taxonomy'],
                          ['E', 'D', 'F'])
-        self.assertEqual(t._observation_metadata[0]['other'], 'h1')
-        self.assertEqual(t._observation_metadata[1]['other'], 'h2')
-        self.assertEqual(t._observation_metadata[2]['other'], 'h3')
+        self.assertEqual(t._observation_metadata.iloc[0]['other'], 'h1')
+        self.assertEqual(t._observation_metadata.iloc[1]['other'], 'h2')
+        self.assertEqual(t._observation_metadata.iloc[2]['other'], 'h3')
 
         samp_md = {4: {'x': 'y', 'foo': 'bar'}, 5: {'x': 'z'}}
         t.add_metadata(samp_md, axis='sample')
-        self.assertEqual(t._sample_metadata[0]['x'], 'y')
-        self.assertEqual(t._sample_metadata[0]['foo'], 'bar')
-        self.assertEqual(t._sample_metadata[1]['x'], 'z')
+        self.assertEqual(t._sample_metadata.iloc[0]['x'], 'y')
+        self.assertEqual(t._sample_metadata.iloc[0]['foo'], 'bar')
+        self.assertEqual(t._sample_metadata.iloc[1]['x'], 'z')
 
     def test_add_metadata_one_w_existing_metadata(self):
         """ add_sample_metadata functions with existing metadata """
@@ -1176,10 +1177,10 @@ class TableTests(TestCase):
         d = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
         t = Table(d, obs_ids, samp_ids, observation_metadata=obs_md,
                   sample_metadata=samp_md)
-        self.assertEqual(t._sample_metadata[0]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[1]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[2]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[3]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[0]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[1]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[2]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[3]['Treatment'], 'Control')
 
         samp_md = {4: {'barcode': 'TTTT'},
                    6: {'barcode': 'AAAA'},
@@ -1187,20 +1188,20 @@ class TableTests(TestCase):
                    7: {'barcode': 'CCCC'},
                    10: {'ignore': 'me'}}
         t.add_metadata(samp_md, 'sample')
-        self.assertEqual(t._sample_metadata[0]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[1]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[2]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[3]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[0]['barcode'], 'TTTT')
-        self.assertEqual(t._sample_metadata[1]['barcode'], 'GGGG')
-        self.assertEqual(t._sample_metadata[2]['barcode'], 'AAAA')
-        self.assertEqual(t._sample_metadata[3]['barcode'], 'CCCC')
+        self.assertEqual(t._sample_metadata.iloc[0]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[1]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[2]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[3]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[0]['barcode'], 'TTTT')
+        self.assertEqual(t._sample_metadata.iloc[1]['barcode'], 'GGGG')
+        self.assertEqual(t._sample_metadata.iloc[2]['barcode'], 'AAAA')
+        self.assertEqual(t._sample_metadata.iloc[3]['barcode'], 'CCCC')
 
         obs_md = {1: {'foo': 'bar'}}
         t.add_metadata(obs_md, axis='observation')
-        self.assertEqual(t._observation_metadata[0]['foo'], 'bar')
-        self.assertEqual(t._observation_metadata[1]['foo'], None)
-        self.assertEqual(t._observation_metadata[2]['foo'], None)
+        self.assertEqual(t._observation_metadata.iloc[0]['foo'], 'bar')
+        self.assertTrue(pd.isnull(t._observation_metadata.iloc[1]['foo']))
+        self.assertTrue(pd.isnull(t._observation_metadata.iloc[2]['foo']))
 
     def test_add_metadata_one_entry(self):
         """ add_sample_metadata functions with single md entry """
@@ -1214,10 +1215,10 @@ class TableTests(TestCase):
         d = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
         t = Table(d, obs_ids, samp_ids, obs_md=obs_md, samp_md=None)
         t.add_metadata(samp_md, axis='sample')
-        self.assertEqual(t._sample_metadata[0]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[1]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[2]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[3]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[0]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[1]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[2]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[3]['Treatment'], 'Control')
 
     def test_add_sample_metadata_two_entries(self):
         """ add_sample_metadata functions with more than one md entry """
@@ -1231,14 +1232,14 @@ class TableTests(TestCase):
         d = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
         t = Table(d, obs_ids, samp_ids, obs_md=obs_md, samp_md=None)
         t.add_metadata(samp_md, axis='sample')
-        self.assertEqual(t._sample_metadata[0]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[1]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[2]['Treatment'], 'Fasting')
-        self.assertEqual(t._sample_metadata[3]['Treatment'], 'Control')
-        self.assertEqual(t._sample_metadata[0]['D'], ['A', 'A'])
-        self.assertEqual(t._sample_metadata[1]['D'], ['A', 'B'])
-        self.assertEqual(t._sample_metadata[2]['D'], ['A', 'C'])
-        self.assertEqual(t._sample_metadata[3]['D'], ['A', 'D'])
+        self.assertEqual(t._sample_metadata.iloc[0]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[1]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[2]['Treatment'], 'Fasting')
+        self.assertEqual(t._sample_metadata.iloc[3]['Treatment'], 'Control')
+        self.assertEqual(t._sample_metadata.iloc[0]['D'], ['A', 'A'])
+        self.assertEqual(t._sample_metadata.iloc[1]['D'], ['A', 'B'])
+        self.assertEqual(t._sample_metadata.iloc[2]['D'], ['A', 'C'])
+        self.assertEqual(t._sample_metadata.iloc[3]['D'], ['A', 'D'])
 
     def test_get_value_by_ids(self):
         """Return the value located in the matrix by the ids"""


### PR DESCRIPTION
This sort of addresses #622

We decided that rather than returning pandas objects, we'll have all of the underlying metadata objects represented as pandas dataframes.

Now since this is a massive undertaking this PR will be split up in to many PRs that will be gradually merged into this PR before going into the master branch.  The PRs will correspond to each function that needs to be changed 

- [x] [add_metadata](https://github.com/mortonjt/biom-format/pull/1)
- [x] [metadata/index](https://github.com/mortonjt/biom-format/pull/2)
- [ ] filter
- [ ] partition
- [ ] collapse
- [ ] merge
- [ ] iter
- [ ] iter_pairwise
- [ ] from_hdf5 / to_hdf5
- [ ] from_json / to_json
- [ ] from_tsv / to_tsv
