### PR TITLE
Concat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ New Features:
 * `Table.rankdata` has been added to convert values to ranked abundances on
   either axis. See [issue #645](https://github.com/biocore/biom-format/issues/639).
 * Format of numbers in ``biom summarize-table`` output is now more readable and localized. See [issue #679](https://github.com/biocore/biom-format/issues/679).
+* `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefit over `Table.merge`.
 
 Bug fixes:
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ New Features:
 * Format of numbers in ``biom summarize-table`` output is now more readable and localized. See [issue #679](https://github.com/biocore/biom-format/issues/679).
 * `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefit over `Table.merge`.
 * `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #720](https://github.com/biocore/biom-format/pull/720)
+* `biom subset-table` now accepts a QIIME-like mapping file when subsetting by IDs [Issue #587](https://github.com/biocore/biom-format/issues/587)
 
 Bug fixes:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ New Features:
   either axis. See [issue #645](https://github.com/biocore/biom-format/issues/639).
 * Format of numbers in ``biom summarize-table`` output is now more readable and localized. See [issue #679](https://github.com/biocore/biom-format/issues/679).
 * `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefit over `Table.merge`.
+* `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #717](https://github.com/biocore/biom-format/pull/717)
 
 Bug fixes:
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,9 @@ New Features:
 * `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #720](https://github.com/biocore/biom-format/pull/720)
 
 Bug fixes:
+
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).
+* Matrices are now cast to csr on `Table` construction if the data evaluate as `isspmatrix`. This fixes [#717](https://github.com/biocore/biom-format/issues/717) where some API methods assumed the data were csc or csr.
 
 biom 2.1.5
 ----------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@ New Features:
 * `Table.rankdata` has been added to convert values to ranked abundances on
   either axis. See [issue #645](https://github.com/biocore/biom-format/issues/639).
 * Format of numbers in ``biom summarize-table`` output is now more readable and localized. See [issue #679](https://github.com/biocore/biom-format/issues/679).
-* `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefit over `Table.merge`.
+* `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefits over `Table.merge`.
 * `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #720](https://github.com/biocore/biom-format/pull/720)
 * `biom subset-table` now accepts a QIIME-like mapping file when subsetting by IDs [Issue #587](https://github.com/biocore/biom-format/issues/587)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@ New Features:
   either axis. See [issue #645](https://github.com/biocore/biom-format/issues/639).
 * Format of numbers in ``biom summarize-table`` output is now more readable and localized. See [issue #679](https://github.com/biocore/biom-format/issues/679).
 * `Table.concat` has been added to the API and allows for concatenating multiple tables in which the IDs of one of the axes are known to be disjoint. This has substantial performance benefit over `Table.merge`.
-* `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #717](https://github.com/biocore/biom-format/pull/717)
+* `Table.sort_order` was performing an implicit cast to dense, and not leveraging fancy indexing. A substantial performance gain was acheived. See [PR #720](https://github.com/biocore/biom-format/pull/720)
 
 Bug fixes:
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).

--- a/biom/cli/table_subsetter.py
+++ b/biom/cli/table_subsetter.py
@@ -64,7 +64,10 @@ def subset_table(input_hdf5_fp, input_json_fp, axis, ids, output_fp):
             input_json_fp = f.read()
 
     with open(ids, 'U') as f:
-        ids = [line.strip() for line in f]
+        ids = []
+        for line in f:
+            if not line.startswith('#'):
+                ids.append(line.strip().split('\t')[0])
 
     table, format_ = _subset_table(input_hdf5_fp, input_json_fp, axis, ids)
 

--- a/biom/cli/table_validator.py
+++ b/biom/cli/table_validator.py
@@ -387,7 +387,7 @@ class TableValidator(object):
         else:
             return ''
 
-    def _check_date(self, val):
+    def _valid_date(self, val):
         valid_times = ["%Y-%m-%d",
                        "%Y-%m-%dT%H:%M",
                        "%Y-%m-%dT%H:%M:%S",
@@ -416,7 +416,7 @@ class TableValidator(object):
                                           note that a 'T' separates the date
                                           and time)
         """
-        return self._check_date(table.attrs['creation-date'])
+        return self._valid_date(table.attrs['creation-date'])
 
     def _valid_datetime(self, table):
         """Verify datetime can be parsed
@@ -425,7 +425,7 @@ class TableValidator(object):
                                           note that a 'T' separates the date
                                           and time)
         """
-        return self._check_date(table['date'])
+        return self._valid_date(table['date'])
 
     def _valid_sparse_data(self, table_json):
         """All index positions must be integers and values are of dtype"""

--- a/biom/err.py
+++ b/biom/err.py
@@ -6,7 +6,7 @@ The error profile object to define different error types and handling within
 BIOM. The following types are registered with the associated default states
 
 empty : 'ignore'
-    Treatment of an empty table (e.g., Table.sum(axis='whole') == 0). If a
+    Treatment of an empty table (e.g., if Table.is_empty() is True). If a
     callable is provided, it implies 'call' and will set the callback function.
 
 obssize : 'raise'

--- a/biom/exception.py
+++ b/biom/exception.py
@@ -31,6 +31,10 @@ class TableException(BiomException):
     pass
 
 
+class DisjointIDError(BiomException):
+    pass
+
+
 class UnknownAxisError(TableException):
     def __init__(self, axis):
         super(UnknownAxisError, self).__init__()

--- a/biom/table.py
+++ b/biom/table.py
@@ -185,7 +185,7 @@ from future.utils import viewitems
 from collections import defaultdict, Hashable, Iterable
 from numpy import ndarray, asarray, zeros, newaxis
 from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, isspmatrix,
-                          vstack, hstack, lil_matrix)
+                          vstack, hstack)
 
 from future.utils import string_types
 from biom.exception import (TableException, UnknownAxisError, UnknownIDError,

--- a/biom/table.py
+++ b/biom/table.py
@@ -184,10 +184,12 @@ from future.builtins import zip
 from future.utils import viewitems
 from collections import defaultdict, Hashable, Iterable
 from numpy import ndarray, asarray, zeros, newaxis
-from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, isspmatrix, vstack
+from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, isspmatrix,
+                          vstack, hstack)
 
 from future.utils import string_types
-from biom.exception import TableException, UnknownAxisError, UnknownIDError
+from biom.exception import (TableException, UnknownAxisError, UnknownIDError,
+                            DisjointIDError)
 from biom.util import (get_biom_format_version_string,
                        get_biom_format_url_string, flatten, natsort,
                        prefer_self, index_list, H5PY_VLEN_STR, HAVE_H5PY,
@@ -2934,6 +2936,160 @@ class Table(object):
                 new_order[id_] = idx
                 idx += 1
         return new_order
+
+    def concat(self, others, axis='sample'):
+        """Concatenate tables if axis is disjoint
+
+        Parameters
+        ----------
+        others : iterable of biom.Table
+            Tables to concatenate
+        axis : {'sample', 'observation'}
+            The axis to concatenate on. i.e., if axis is 'sample', then tables
+            will be joined such that the set of sample IDs in the resulting
+            table will be the union of sample IDs across all tables in others.
+
+        Raises
+        ------
+        DisjointIDError
+            If IDs over the axis are not disjoint.
+
+        Examples
+        --------
+        Concatenate three tables in which the sample IDs are disjoint. Note
+        the observation IDs in this example are not disjoint (although they
+        can be):
+
+        >>> from biom import Table
+        >>> import numpy as np
+        >>> a = Table(np.array([[0, 1, 2], [3, 4, 5]]), ['O1', 'O2'],
+        ...                     ['S1', 'S2', 'S3'],
+        ...                     [{'taxonomy': 'foo'}, {'taxonomy': 'bar'}])
+        >>> b = Table(np.array([[6, 7, 8], [9, 10, 11]]), ['O3', 'O4'],
+        ...                     ['S4', 'S5', 'S6'],
+        ...                     [{'taxonomy': 'baz'}, {'taxonomy': 'foobar'}])
+        >>> c = Table(np.array([[12, 13, 14], [15, 16, 17]]), ['O1', 'O5'],
+        ...                     ['S7', 'S8', 'S9'],
+        ...                     [{'taxonomy': 'foo'}, {'taxonomy': 'biz'}])
+        >>> d = a.concat([b, c])
+        >>> print(d)  # doctest: +NORMALIZE_WHITESPACE
+        # Constructed from biom file
+        #OTU ID	S1	S2	S3	S4	S5	S6	S7	S8	S9
+        O1	0.0	1.0	2.0	0.0	0.0	0.0	12.0	13.0	14.0
+        O2	3.0	4.0	5.0	0.0	0.0	0.0	0.0	0.0	0.0
+        O3	0.0	0.0	0.0	6.0	7.0	8.0	0.0	0.0	0.0
+        O4	0.0	0.0	0.0	9.0	10.0	11.0	0.0	0.0	0.0
+        O5	0.0	0.0	0.0	0.0	0.0	0.0	15.0	16.0	17.0
+
+        """
+        # should this be a staticmethod?
+
+        # we grow along the opposite axis
+        invaxis = self._invert_axis(axis)
+        if axis == 'sample':
+            dim_getter = itemgetter(1)
+            stack = hstack
+            invstack = vstack
+        else:
+            dim_getter = itemgetter(0)
+            stack = vstack
+            invstack = hstack
+
+        axis_ids = set()
+        invaxis_ids = set()
+        invaxis_metadata = {}
+
+        all_tables = others[:]
+        all_tables.insert(0, self)
+
+        for table in all_tables:
+            table_axis_ids = table.ids(axis=axis)
+            table_invaxis_order = table.ids(axis=invaxis)
+            table_invaxis = set(table_invaxis_order)
+
+            # test we have disjoint IDs
+            if not axis_ids.isdisjoint(table_axis_ids):
+                raise DisjointIDError("IDs are not disjoint")
+            axis_ids.update(table_axis_ids)
+
+            if set(table_invaxis) - invaxis_ids:
+                for i in (set(table_invaxis) - invaxis_ids):
+                    invaxis_metadata[i] = table.metadata(i, axis=invaxis)
+
+                # add to our perspective all inv axis IDs
+                invaxis_ids.update(table_invaxis)
+
+        invaxis_order = sorted(invaxis_ids)
+
+        # determine what inv axis IDs do not exist per table
+        padded_tables = []
+        for table in all_tables:
+            missing_ids = list(invaxis_ids - set(table.ids(axis=invaxis)))
+
+            if missing_ids:
+                # determine new shape
+                n_invaxis = len(missing_ids)
+                n_axis = len(table.ids(axis=axis))
+                if axis == 'sample':
+                    shape = (n_invaxis, n_axis)
+                else:
+                    shape = (n_axis, n_invaxis)
+
+                # create the padded matrix
+                zerod = csr_matrix(shape)
+                tmp_mat = invstack([table.matrix_data, zerod])
+
+                # resolve invert axis ids and metadata
+                tmp_inv_ids = list(table.ids(axis=invaxis))
+                tmp_inv_ids.extend(missing_ids)
+                tmp_inv_md = table.metadata(axis=invaxis)
+                if tmp_inv_md is None:
+                    tmp_inv_md = [None] * len(table.ids())
+                else:
+                    tmp_inv_md = list(tmp_inv_md)
+                tmp_inv_md.extend([invaxis_metadata[i] for i in missing_ids])
+
+                # resolve axis ids and metadata
+                tmp_ids = list(table.ids(axis=axis))
+                tmp_md = table.metadata(axis=axis)
+
+                # this sucks.
+                if axis == 'sample':
+                    tmp_table = self.__class__(tmp_mat, tmp_inv_ids, tmp_ids,
+                                               tmp_inv_md, tmp_md)
+                else:
+                    tmp_table = self.__class__(tmp_mat, tmp_ids, tmp_inv_ids,
+                                               tmp_md, tmp_inv_md)
+            else:
+                tmp_table = table
+
+            # sort the table if necessary
+            if (tmp_table.ids(axis=invaxis) == invaxis_order).all():
+                padded_tables.append(tmp_table)
+            else:
+                padded_tables.append(tmp_table.sort_order(invaxis_order,
+                                                          axis=invaxis))
+
+        # actually concatenate the matrices, IDs and metadata
+        concat_mat = stack([t.matrix_data for t in padded_tables])
+        concat_ids = np.concatenate([t.ids(axis=axis) for t in padded_tables])
+        concat_md = []
+        for table in padded_tables:
+            metadata = table.metadata(axis=axis)
+            if metadata is None:
+                metadata = [None] * dim_getter(table.shape)
+            concat_md.extend(metadata)
+
+        # inverse axis sourced from whatever is in the first table
+        inv_md = padded_tables[0].metadata(axis=invaxis)
+        if axis == 'sample':
+            concat = self.__class__(concat_mat, invaxis_order, concat_ids,
+                                    inv_md, concat_md)
+        else:
+            concat = self.__class__(concat_mat, concat_ids, invaxis_order,
+                                    concat_md, inv_md)
+
+        return concat
 
     def merge(self, other, sample='union', observation='union',
               sample_metadata_f=prefer_self,

--- a/biom/table.py
+++ b/biom/table.py
@@ -2966,8 +2966,6 @@ class Table(object):
         O5	0.0	0.0	0.0	0.0	0.0	0.0	15.0	16.0	17.0
 
         """
-        # should this be a staticmethod?
-
         # we grow along the opposite axis
         invaxis = self._invert_axis(axis)
         if axis == 'sample':
@@ -3039,7 +3037,8 @@ class Table(object):
                 tmp_ids = list(table.ids(axis=axis))
                 tmp_md = table.metadata(axis=axis)
 
-                # this sucks.
+                # resolve construction based off axis. This really should be
+                # pushed to a classmethod.
                 if axis == 'sample':
                     tmp_table = self.__class__(tmp_mat, tmp_inv_ids, tmp_ids,
                                                tmp_inv_md, tmp_md)

--- a/biom/table.py
+++ b/biom/table.py
@@ -2928,7 +2928,7 @@ class Table(object):
         ----------
         others : iterable of biom.Table
             Tables to concatenate
-        axis : {'sample', 'observation'}
+        axis : {'sample', 'observation'}, optional
             The axis to concatenate on. i.e., if axis is 'sample', then tables
             will be joined such that the set of sample IDs in the resulting
             table will be the union of sample IDs across all tables in others.

--- a/biom/table.py
+++ b/biom/table.py
@@ -2986,6 +2986,7 @@ class Table(object):
         all_tables = others[:]
         all_tables.insert(0, self)
 
+        # verify disjoint, and fetch all ids from all tables
         for table in all_tables:
             table_axis_ids = table.ids(axis=axis)
             table_invaxis_order = table.ids(axis=invaxis)
@@ -3005,7 +3006,8 @@ class Table(object):
 
         invaxis_order = sorted(invaxis_ids)
 
-        # determine what inv axis IDs do not exist per table
+        # determine what inv axis IDs do not exist per table, and pad and sort
+        # as necessary
         padded_tables = []
         for table in all_tables:
             missing_ids = list(invaxis_ids - set(table.ids(axis=invaxis)))

--- a/biom/table.py
+++ b/biom/table.py
@@ -2867,8 +2867,8 @@ class Table(object):
         axis : {'sample', 'observation', 'whole'}
             The axis on which to count nonzero entries
         binary : bool, optional
-            Defaults to ``False``. If ``False``, return number of nonzero
-            entries. If ``True``, sum the values of the entries.
+            Defaults to ``False``. If ``True``, return number of nonzero
+            entries. If ``False``, sum the values of the entries.
 
         Returns
         -------

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ classes = """
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
     Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: OS Independent
     Operating System :: POSIX :: Linux

--- a/support_files/biom_config
+++ b/support_files/biom_config
@@ -1,7 +1,0 @@
-# biom_config
-# WARNING: DO NOT EDIT OR DELETE biom-format/support_files/biom_config
-# To overwrite defaults, copy this file to $HOME/.biom_config or a full path
-# specified by $BIOM_CONFIG_FP and edit that copy of the file.
-
-# The sparse matrix backend to use (either CSMat or ScipySparseMat).
-python_code_sparse_backend	ScipySparseMat

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -99,6 +99,11 @@ class SupportTests(TestCase):
         with self.assertRaises(IndexError):
             example_table.head(5, 0)
 
+    def test_concat_empty(self):
+        exp = example_table.copy()
+        obs = example_table.concat([])
+        self.assertEqual(obs, exp)
+
     def test_concat_samples(self):
         table2 = example_table.copy()
         table2.update_ids({'S1': 'S4', 'S2': 'S5', 'S3': 'S6'})

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -19,6 +19,7 @@ from future.utils import viewkeys
 import numpy.testing as npt
 import numpy as np
 from scipy.sparse import lil_matrix, csr_matrix, csc_matrix
+import scipy.sparse
 
 from biom import example_table
 from biom.exception import (UnknownAxisError, UnknownIDError, TableException,
@@ -1710,6 +1711,15 @@ class SparseTableTests(TestCase):
         obs = self.st1.update_ids({'a': 'x', 'b': 'y'}, inplace=False)
         exp_index = {'x': 0, 'y': 1}
         self.assertEqual(obs._sample_index, exp_index)
+
+    def test_other_spmatrix_type(self):
+        # I dont actually remember what bug stemmed from this...
+        ss = scipy.sparse
+        for c in [ss.lil_matrix, ss.bsr_matrix, ss.coo_matrix, ss.dia_matrix,
+                  ss.dok_matrix, ss.csc_matrix, ss.csr_matrix]:
+            mat = c((2, 2))
+            t = Table(mat, ['a', 'b'], [1, 2])
+            self.assertTrue(isinstance(t.matrix_data, (csr_matrix, csc_matrix)))
 
     def test_sort_order(self):
         """sorts tables by arbitrary order"""


### PR DESCRIPTION
Resolves #716. This ended up growing in complexity to handle the general case in which one set of IDs are disjoint while the other axis doesn't need to be. I'd be curious if others see ways to reduce or simplify some of the code complexity here. 

Now, why is this method useful? Often, when merging tables, one axis is disjoint (e.g., the sample IDs in a meta-analysis). This method offers 80x or so improvement over the existing `merge` method for this case. In addition, it supports concatenating multiple tables while `merge` must operate only on pairs thus offering likely further performance gains in real world scenarios.

The first benchmark shows approximately a 20x improvement. When profiling, a hotspot was identified in `sort_order`, which was also rectified.

```python
In [1]: import biom

In [2]: a = biom.load_table('twins.qiita-2014.biom')

In [3]: b = biom.load_table('ag.qiita-10317.biom')

In [4]: a
Out[4]: 8735 x 1046 <class 'biom.table.Table'> with 344079 nonzero entries (3% dense)

In [5]: b
Out[5]: 9128 x 9919 <class 'biom.table.Table'> with 1508178 nonzero entries (1% dense)

In [6]: %timeit c = a.concat([b])
1 loop, best of 3: 2.25 s per loop

In [7]: %timeit c = a.merge(b)
1 loop, best of 3: 43.9 s per loop
```

A quick profile suggested a hotspot in `sort_order` stemming from a) an implicit cast to dense (which also stood to bloat memory) and b) utilizing incremental indexing instead of fancy indexing. So I fixed that. New timing below:

```python
In [1]: import biom

In [2]: a = biom.load_table('twins.qiita-2014.biom')

In [3]: b = biom.load_table('ag.qiita-10317.biom')

In [4]: %timeit c = a.concat([b])
1 loop, best of 3: 582 ms per loop
```