### PR TITLE
BUG/TST: concat was not handling missing metadata properly

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Bug fixes:
 
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).
 * Matrices are now cast to csr on `Table` construction if the data evaluate as `isspmatrix`. This fixes [#717](https://github.com/biocore/biom-format/issues/717) where some API methods assumed the data were csc or csr.
+* `Table.concat` was not handling the situation where tables did not have metadata correctly, resulting in an exception due to mismatches metadata shape. 
 
 biom 2.1.5
 ----------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@ Bug fixes:
 
 * ``-o`` is now a required parameter of ``biom from-uc``. This was not the case previously, which resulted in a cryptic error message if ``-o`` was not provided. See [issue #683](https://github.com/biocore/biom-format/issues/683).
 * Matrices are now cast to csr on `Table` construction if the data evaluate as `isspmatrix`. This fixes [#717](https://github.com/biocore/biom-format/issues/717) where some API methods assumed the data were csc or csr.
-* `Table.concat` was not handling the situation where tables did not have metadata correctly, resulting in an exception due to mismatches metadata shape. 
+* `Table.concat` was not handling tables without metadata, resulting in an exception due to mismatches metadata shape. See [#724](https://github.com/biocore/biom-format/issues/724).
 
 biom 2.1.5
 ----------

--- a/biom/table.py
+++ b/biom/table.py
@@ -3028,7 +3028,7 @@ class Table(object):
                 tmp_inv_ids.extend(missing_ids)
                 tmp_inv_md = table.metadata(axis=invaxis)
                 if tmp_inv_md is None:
-                    tmp_inv_md = [None] * len(table.ids())
+                    tmp_inv_md = [None] * len(table.ids(axis=invaxis))
                 else:
                     tmp_inv_md = list(tmp_inv_md)
                 tmp_inv_md.extend([invaxis_metadata[i] for i in missing_ids])

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -186,6 +186,25 @@ class SupportTests(TestCase):
 
         obs = example_table.concat([table2, ], axis='sample')
         self.assertEqual(obs, exp)
+    
+    def test_concat_no_metadata_bug(self):
+        table1 = example_table.copy()
+        table1._sample_metadata = None
+        table1._observation_metadata = None
+        table2 = example_table.copy()
+        table2._sample_metadata = None
+        table2._observation_metadata = None
+        table2.update_ids({'O2': 'O3'}, axis='observation', strict=False)
+        table2.update_ids({'S1': 'S4', 'S2': 'S5', 'S3': 'S6'})
+
+        exp = Table(np.array([[0, 1, 2, 0, 1, 2],
+                              [3, 4, 5, 0, 0, 0],
+                              [0, 0, 0, 3, 4, 5]]),
+                    ['O1', 'O2', 'O3'],
+                    ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'])
+
+        obs = table1.concat([table2, ], axis='sample')
+        self.assertEqual(obs, exp)
 
     def test_concat_raise_overlap(self):
         with self.assertRaises(DisjointIDError):
@@ -1718,7 +1737,6 @@ class SparseTableTests(TestCase):
         self.assertEqual(obs._sample_index, exp_index)
 
     def test_other_spmatrix_type(self):
-        # I dont actually remember what bug stemmed from this...
         ss = scipy.sparse
         for c in [ss.lil_matrix, ss.bsr_matrix, ss.coo_matrix, ss.dia_matrix,
                   ss.dok_matrix, ss.csc_matrix, ss.csr_matrix]:


### PR DESCRIPTION
Tables w/o metadata weren't concatenating correctly. 