### PR TITLE
ENH: work around possible broken pipe errors

### DIFF
--- a/biom/cli/__init__.py
+++ b/biom/cli/__init__.py
@@ -14,10 +14,18 @@ import click
 import biom
 
 
+def _terribly_handle_brokenpipeerror():
+    # based off http://stackoverflow.com/a/34299346
+    import os
+    import sys
+    sys.stdout = os.fdopen(1, 'w')
+
+
 @click.group(context_settings=dict(help_option_names=['-h', '--help']))
 @click.version_option(version=biom.__version__)
-def cli():
-    pass
+@click.pass_context
+def cli(ctx):
+    ctx.call_on_close(_terribly_handle_brokenpipeerror)
 
 
 import_module('biom.cli.table_summarizer')
@@ -27,5 +35,6 @@ import_module('biom.cli.installation_informer')
 import_module('biom.cli.table_subsetter')
 import_module('biom.cli.table_normalizer')
 import_module('biom.cli.table_head')
+import_module('biom.cli.table_ids')
 import_module('biom.cli.table_validator')
 import_module('biom.cli.uc_processor')


### PR DESCRIPTION
Another small one. `BrokenPipeErrors` can happen when piping from a python process to something else, eg `biom table-ids -i foo | head`. This is inelegant, but the issue is rather low level in Python itself. 