### PR TITLE
BUG: All ints should be accepted

### DIFF
--- a/biom/cli/table_validator.py
+++ b/biom/cli/table_validator.py
@@ -343,8 +343,8 @@ class TableValidator(object):
             return key
 
     def _is_int(self, x):
-        """Return True if x is an int"""
-        return isinstance(x, (int, np.int64))
+        """Return True if x is an int or numpy int"""
+        return np.issubdtype(type(x), np.integer)
 
     def _valid_nnz(self, table):
         """Check if nnz seems correct"""

--- a/tests/test_cli/test_validate_table.py
+++ b/tests/test_cli/test_validate_table.py
@@ -22,6 +22,7 @@ import json
 from unittest import TestCase, main
 from shutil import copy
 
+import numpy as np
 import numpy.testing as npt
 
 from biom.cli.table_validator import TableValidator
@@ -161,6 +162,19 @@ class TableValidatorTests(TestCase):
         table['format_url'] = 'foo'
         obs = self.cmd._valid_format_url(table)
         self.assertTrue(len(obs) > 0)
+
+    def test_is_int(self):
+        self.assertTrue(self.cmd._is_int(3))
+
+        self.assertFalse(self.cmd._is_int(3.5))
+
+        # checking with numpy dtypes
+        self.assertFalse(self.cmd._is_int(np.float64(3)))
+        self.assertFalse(self.cmd._is_int(np.float32(3)))
+
+        self.assertTrue(self.cmd._is_int(np.int64(3)))
+        self.assertTrue(self.cmd._is_int(np.int32(3)))
+        self.assertTrue(self.cmd._is_int(np.int16(3)))
 
     def test_valid_format(self):
         """Should match format string"""


### PR DESCRIPTION
This had the consequence of flagging tables as invalid when nnz values were
stored as np.int32 or np.int16 (somehow this happened for a Qiita table).

The format document specifies that this value should be int, but it doesn't specify
the specific representation, so I assume all subdtypes of np.integer should be safe.