### PR TITLE
Some additional error checking on to_hdf5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n env_name python=$PYTHON_VERSION pip click numpy scipy nose pep8 flake8 coverage future six pandas
+  - conda create --yes -n env_name python=$PYTHON_VERSION pip click "numpy < 1.14.0" scipy nose pep8 flake8 coverage future six pandas
   - if [ ${USE_CYTHON} ]; then conda install --yes -n env_name cython; fi
   - if [ ${USE_H5PY} ]; then conda install --yes -n env_name h5py>=2.2.0; fi
   - if [ ${PYTHON_VERSION} = "2.7" ]; then conda install --yes -n env_name Sphinx=1.2.2; fi

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@ Changes since 2.1.6 go here.
 
 New Features:
 
+* Added additional sanity checks when calling `Table.to_hdf5`, see [PR #foo](...).
+
 Bug fixes:
 
 * `Table.subsample(by_id=True, axis='observation')` did not subsample over the 'observations'. Because of the nature of the bug, an empty table was returned, so the scope of the issue is such that it should not have produced misleading results but instead triggered empty table errors, with the exception of the pathological case of the ID namespaces between features and samples not being disjoint. See [PR #759](https://github.com/biocore/biom-format/pull/759) for more information.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ Changes since 2.1.6 go here.
 
 New Features:
 
-* Added additional sanity checks when calling `Table.to_hdf5`, see [PR #foo](...).
+* Added additional sanity checks when calling `Table.to_hdf5`, see [PR #769](https://github.com/biocore/biom-format/pull/769).
 
 Bug fixes:
 

--- a/biom/cli/table_validator.py
+++ b/biom/cli/table_validator.py
@@ -401,7 +401,7 @@ class TableValidator(object):
                 datetime.strptime(val, fmt)
                 valid_time = True
                 break
-            except:
+            except:  # noqa
                 pass
 
         if valid_time:
@@ -437,7 +437,7 @@ class TableValidator(object):
         for idx, coord in enumerate(table_json['data']):
             try:
                 x, y, val = coord
-            except:
+            except:  # noqa
                 return "Bad matrix entry idx %d: %s" % (idx, repr(coord))
 
             if not self._is_int(x) or not self._is_int(y):

--- a/biom/parse.py
+++ b/biom/parse.py
@@ -391,7 +391,9 @@ def parse_biom_table(fp, ids=None, axis='sample', input_is_dense=False):
 
     try:
         return Table.from_hdf5(fp, ids=ids, axis=axis)
-    except:
+    except ValueError:
+        pass
+    except RuntimeError:
         pass
     if hasattr(fp, 'read'):
         old_pos = fp.tell()

--- a/biom/table.py
+++ b/biom/table.py
@@ -202,7 +202,7 @@ from ._transform import _transform
 from ._subsample import _subsample
 
 
-if six.PY3:
+if not six.PY3:
     string_types = list(_future_string_types)
     string_types.append(str)
     string_types.append(unicode)

--- a/biom/table.py
+++ b/biom/table.py
@@ -249,7 +249,7 @@ def _identify_bad_value(dtype, fields):
     for idx, v in enumerate(fields):
         try:
             dtype(v)
-        except:
+        except:  # noqa
             badval = v
             badidx = idx
             break
@@ -346,7 +346,7 @@ def vlen_list_of_str_formatter(grp, header, md, compression):
                     new_md.append({header: parts})
                     lengths.append(len(parts))
                 md = new_md
-            except:
+            except:  # noqa
                 raise TypeError("Category '%s' is not formatted properly. The "
                                 "most common issue is when 'taxonomy' is "
                                 "represented as a flat string instead of a "
@@ -879,7 +879,7 @@ class Table(object):
 
         try:
             row, col = args
-        except:
+        except:  # noqa
             raise IndexError("Must specify (row, col).")
 
         if isinstance(row, slice) and isinstance(col, slice):
@@ -4367,7 +4367,7 @@ html
         # the matrix is.
         try:
             num_rows, num_cols = self.shape
-        except:
+        except:  # noqa
             num_rows = num_cols = 0
         has_data = True if num_rows > 0 and num_cols > 0 else False
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -3695,6 +3695,7 @@ dataset of int32
         ValueError
             If `ids` are not a subset of the samples or observations ids
             present in the hdf5 biom table
+            If h5grp is not a HDF5 file or group
 
         References
         ----------
@@ -3728,6 +3729,10 @@ html
         if not HAVE_H5PY:
             raise RuntimeError("h5py is not in the environment, HDF5 support "
                                "is not available")
+
+        if not isinstance(h5grp, (h5py.Group, h5py.File)):
+            raise ValueError("h5grp does not appear to be an HDF5 file or "
+                             "group")
 
         if axis not in ['sample', 'observation']:
             raise UnknownAxisError(axis)

--- a/biom/table.py
+++ b/biom/table.py
@@ -4156,7 +4156,6 @@ html
         formatter.update(format_fs)
 
         for axis, order in zip(['observation', 'sample'], ['csr', 'csc']):
-        #def axis_dump(grp, ids, md, group_md, order, compression=None):
             grp = h5grp.create_group(axis)
 
             self._data = self._data.asformat(order)
@@ -4225,11 +4224,6 @@ html
                 # Empty H5PY_VLEN_STR datasets are not supported.
                 grp.create_dataset('ids', shape=(0, ), data=[],
                                    compression=compression)
-
-        #axis_dump(h5grp.create_group('observation'),
-         #         self.ids(axis='observation'),
-          #        self.metadata(axis='observation'),
-           #       self.group_metadata(axis='observation'), 'csr', compression)
 
     @classmethod
     def from_json(self, json_table, data_pump=None,

--- a/biom/table.py
+++ b/biom/table.py
@@ -189,7 +189,7 @@ from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, isspmatrix,
 import pandas as pd
 
 import six
-from future.utils import string_types
+from future.utils import string_types as _future_string_types
 from biom.exception import (TableException, UnknownAxisError, UnknownIDError,
                             DisjointIDError)
 from biom.util import (get_biom_format_version_string,
@@ -200,6 +200,15 @@ from biom.err import errcheck
 from ._filter import _filter
 from ._transform import _transform
 from ._subsample import _subsample
+
+
+if six.PY3:
+    string_types = list(_future_string_types)
+    string_types.append(str)
+    string_types.append(unicode)
+    string_types = tuple(string_types)
+else:
+    string_types = _future_string_types
 
 
 __author__ = "Daniel McDonald"

--- a/biom/table.py
+++ b/biom/table.py
@@ -205,7 +205,7 @@ from ._subsample import _subsample
 if not six.PY3:
     string_types = list(_future_string_types)
     string_types.append(str)
-    string_types.append(unicode)
+    string_types.append(unicode)  # noqa
     string_types = tuple(string_types)
 else:
     string_types = _future_string_types

--- a/biom/table.py
+++ b/biom/table.py
@@ -265,20 +265,42 @@ def vlen_list_of_str_parser(value):
 
 def general_formatter(grp, header, md, compression):
     """Creates a dataset for a general atomic type category"""
-    test_val = md[0][header]
     shape = (len(md),)
     name = 'metadata/%s' % header
-    if isinstance(test_val, string_types):
+    dtypes = [type(m[header]) for m in md]
+
+    if set(dtypes).issubset(set(string_types)):
         grp.create_dataset(name, shape=shape,
                            dtype=H5PY_VLEN_STR,
                            data=[m[header].encode('utf8') for m in md],
                            compression=compression)
-    elif isinstance(test_val, (list, tuple)):
+    elif set(dtypes).issubset({list, tuple}):
         vlen_list_of_str_formatter(grp, header, md, compression)
     else:
+        formatted = []
+        dtypes_used = []
+        for dt, m in zip(dtypes, md):
+            val = m[header]
+            if val is None:
+                val = '\0'
+                dt = str
+
+            if dt in string_types:
+                val = val.encode('utf8')
+
+            formatted.append(val)
+            dtypes_used.append(dt)
+
+        if set(dtypes_used).issubset(set(string_types)):
+            dtype_to_use = H5PY_VLEN_STR
+        else:
+            dtype_to_use = None
+
+        # try our best...
         grp.create_dataset(
             name, shape=(len(md),),
-            data=[m[header] for m in md],
+            dtype=dtype_to_use,
+            data=formatted,
             compression=compression)
 
 
@@ -4114,16 +4136,71 @@ html
         if format_fs is None:
             format_fs = {}
 
-        def axis_dump(grp, ids, md, group_md, order, compression=None):
-            """Store for an axis"""
+        h5grp.attrs['id'] = self.table_id if self.table_id else "No Table ID"
+        h5grp.attrs['type'] = self.type if self.type else ""
+        h5grp.attrs['format-url'] = "http://biom-format.org"
+        h5grp.attrs['format-version'] = self.format_version
+        h5grp.attrs['generated-by'] = generated_by
+        h5grp.attrs['creation-date'] = datetime.now().isoformat()
+        h5grp.attrs['shape'] = self.shape
+        h5grp.attrs['nnz'] = self.nnz
+
+        compression = None
+        if compress is True:
+            compression = 'gzip'
+
+        formatter = defaultdict(lambda: general_formatter)
+        formatter['taxonomy'] = vlen_list_of_str_formatter
+        formatter['KEGG_Pathways'] = vlen_list_of_str_formatter
+        formatter['collapsed_ids'] = vlen_list_of_str_formatter
+        formatter.update(format_fs)
+
+        for axis, order in zip(['observation', 'sample'], ['csr', 'csc']):
+        #def axis_dump(grp, ids, md, group_md, order, compression=None):
+            grp = h5grp.create_group(axis)
+
             self._data = self._data.asformat(order)
 
+            ids = self.ids(axis=axis)
             len_ids = len(ids)
             len_indptr = len(self._data.indptr)
             len_data = self.nnz
 
-            grp.create_group('matrix')
+            md = self.metadata(axis=axis)
 
+            # Create the group for the metadata
+            grp.create_group('metadata')
+            if md is not None:
+                exp = set(md[0])
+                for other_id, other_md in zip(ids[1:], md[1:]):
+                    if set(other_md) != exp:
+                        raise ValueError("%s has inconsistent metadata "
+                                         "categories with %s:\n"
+                                         "%s: %s\n"
+                                         "%s: %s" % (other_id, ids[0],
+                                                     other_id, list(other_md),
+                                                     ids[0], list(exp)))
+
+                for category in md[0]:
+                    # Create the dataset for the current category,
+                    # putting values in id order
+                    formatter[category](grp, category, md, compression)
+
+            group_md = self.group_metadata(axis)
+
+            # Create the group for the group metadata
+            grp.create_group('group-metadata')
+
+            if group_md:
+                for key, value in group_md.items():
+                    datatype, val = value
+                    grp_dataset = grp.create_dataset(
+                        'group-metadata/%s' % key,
+                        shape=(1,), dtype=H5PY_VLEN_STR,
+                        data=val, compression=compression)
+                    grp_dataset.attrs['data_type'] = datatype
+
+            grp.create_group('matrix')
             grp.create_dataset('matrix/data', shape=(len_data,),
                                dtype=np.float64,
                                data=self._data.data,
@@ -4149,50 +4226,10 @@ html
                 grp.create_dataset('ids', shape=(0, ), data=[],
                                    compression=compression)
 
-            # Create the group for the metadata
-            grp.create_group('metadata')
-
-            if md is not None:
-                formatter = defaultdict(lambda: general_formatter)
-                formatter['taxonomy'] = vlen_list_of_str_formatter
-                formatter['KEGG_Pathways'] = vlen_list_of_str_formatter
-                formatter['collapsed_ids'] = vlen_list_of_str_formatter
-                formatter.update(format_fs)
-                # Loop through all the categories
-                for category in md[0]:
-                    # Create the dataset for the current category,
-                    # putting values in id order
-                    formatter[category](grp, category, md, compression)
-
-            # Create the group for the group metadata
-            grp.create_group('group-metadata')
-
-            if group_md:
-                for key, value in group_md.items():
-                    datatype, val = value
-                    grp_dataset = grp.create_dataset(
-                        'group-metadata/%s' % key,
-                        shape=(1,), dtype=H5PY_VLEN_STR,
-                        data=val, compression=compression)
-                    grp_dataset.attrs['data_type'] = datatype
-
-        h5grp.attrs['id'] = self.table_id if self.table_id else "No Table ID"
-        h5grp.attrs['type'] = self.type if self.type else ""
-        h5grp.attrs['format-url'] = "http://biom-format.org"
-        h5grp.attrs['format-version'] = self.format_version
-        h5grp.attrs['generated-by'] = generated_by
-        h5grp.attrs['creation-date'] = datetime.now().isoformat()
-        h5grp.attrs['shape'] = self.shape
-        h5grp.attrs['nnz'] = self.nnz
-        compression = None
-        if compress is True:
-            compression = 'gzip'
-        axis_dump(h5grp.create_group('observation'),
-                  self.ids(axis='observation'),
-                  self.metadata(axis='observation'),
-                  self.group_metadata(axis='observation'), 'csr', compression)
-        axis_dump(h5grp.create_group('sample'), self.ids(),
-                  self.metadata(), self.group_metadata(), 'csc', compression)
+        #axis_dump(h5grp.create_group('observation'),
+         #         self.ids(axis='observation'),
+          #        self.metadata(axis='observation'),
+           #       self.group_metadata(axis='observation'), 'csr', compression)
 
     @classmethod
     def from_json(self, json_table, data_pump=None,

--- a/biom/table.py
+++ b/biom/table.py
@@ -3730,6 +3730,7 @@ html
             raise RuntimeError("h5py is not in the environment, HDF5 support "
                                "is not available")
 
+        import h5py
         if not isinstance(h5grp, (h5py.Group, h5py.File)):
             raise ValueError("h5grp does not appear to be an HDF5 file or "
                              "group")

--- a/biom/table.py
+++ b/biom/table.py
@@ -3696,7 +3696,6 @@ dataset of int32
             If `ids` are not a subset of the samples or observations ids
             present in the hdf5 biom table
 
-
         References
         ----------
         .. [1] http://docs.scipy.org/doc/scipy-0.13.0/reference/generated/sci\

--- a/biom/util.py
+++ b/biom/util.py
@@ -154,7 +154,7 @@ def flatten(items):
     for i in items:
         try:
             result.extend(i)
-        except:
+        except:  # noqa
             result.append(i)
     return result
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,10 @@ if USE_CYTHON:
     from Cython.Build import cythonize
     extensions = cythonize(extensions)
 
-install_requires = ["click", "numpy >= 1.3.0", "future >= 0.16.0",
+# A justification for the numpy pinning can be found in scikit-bio 0.5.4
+# In brief, numpy 1.14.0 introduced whitespace changes that impact repr
+# on doctest
+install_requires = ["click", "numpy >= 1.9.2, < 1.14.0", "future >= 0.16.0",
                     "scipy >= 0.13.0", 'pandas >= 0.19.2',
                     "six >= 1.10.0"]
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -519,6 +519,11 @@ class TableTests(TestCase):
         npt.assert_equal(obs, exp)
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
+    def test_from_hdf5_non_hdf5_file_or_group(self):
+        with self.assertRaises(ValueError):
+            Table.from_hdf5(10)
+
+    @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_from_hdf5_empty_md(self):
         """Parse a hdf5 formatted BIOM table w/o metadata"""
         cwd = os.getcwd()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -900,9 +900,13 @@ class TableTests(TestCase):
 
         with NamedTemporaryFile() as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
-                with self.assertRaisesRegex(ValueError,
-                                            'inconsistent metadata'):
-                    t.to_hdf5(h5, 'tests')
+                if six.PY3:
+                    with self.assertRaisesRegex(ValueError,
+                                                'inconsistent metadata'):
+                        t.to_hdf5(h5, 'tests')
+                else:
+                    with self.assertRaises(ValueError):
+                        t.to_hdf5(h5, 'tests')
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_to_hdf5_inconsistent_metadata_categories_sample(self):
@@ -913,9 +917,13 @@ class TableTests(TestCase):
 
         with NamedTemporaryFile() as tmpfile:
             with h5py.File(tmpfile.name, 'w') as h5:
-                with self.assertRaisesRegex(ValueError,
-                                            'inconsistent metadata'):
-                    t.to_hdf5(h5, 'tests')
+                if six.PY3:
+                    with self.assertRaisesRegex(ValueError,
+                                                'inconsistent metadata'):
+                        t.to_hdf5(h5, 'tests')
+                else:
+                    with self.assertRaises(ValueError):
+                        t.to_hdf5(h5, 'tests')
 
     @npt.dec.skipif(HAVE_H5PY is False, msg='H5PY is not installed')
     def test_to_hdf5_malformed_taxonomy(self):


### PR DESCRIPTION
Some additional error checking when writing out to HDF5, with some additional care on the general formatter. 

The metadata are still quite awkward, and this further underscores the need to transition the metadata representation to `pandas`. 