### PR TITLE
Issue594

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ Bug fixes:
 
 * `Table.subsample(by_id=True, axis='observation')` did not subsample over the 'observations'. Because of the nature of the bug, an empty table was returned, so the scope of the issue is such that it should not have produced misleading results but instead triggered empty table errors, with the exception of the pathological case of the ID namespaces between features and samples not being disjoint. See [PR #759](https://github.com/biocore/biom-format/pull/759) for more information.
 * Tables of shape `(0, n)` or `(n, 0)` were raising exceptions when being written out. See [issue #619](https://github.com/biocore/biom-format/issues/619).
+* Tables loaded with a `list` of empty `dict`s will have their metadata attributes set to None. See [issue #594](https://github.com/biocore/biom-format/issues/594).
 
 biom 2.1.6
 ----------

--- a/biom/table.py
+++ b/biom/table.py
@@ -483,12 +483,22 @@ class Table(object):
         self._observation_ids = np.asarray(observation_ids, dtype=object)
 
         if sample_metadata is not None:
-            self._sample_metadata = tuple(sample_metadata)
+            # not m will evaluate True if the object tested is None or
+            # an empty dict, etc.
+            if {not m for m in sample_metadata} == {True, }:
+                self._sample_metadata = None
+            else:
+                self._sample_metadata = tuple(sample_metadata)
         else:
             self._sample_metadata = None
 
         if observation_metadata is not None:
-            self._observation_metadata = tuple(observation_metadata)
+            # not m will evaluate True if the object tested is None or
+            # an empty dict, etc.
+            if {not m for m in observation_metadata} == {True, }:
+                self._observation_metadata = None
+            else:
+                self._observation_metadata = tuple(observation_metadata)
         else:
             self._observation_metadata = None
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -295,6 +295,18 @@ class ParseTests(TestCase):
         t_json = parse_biom_table(t_json_stringio)
         self.assertEqual(t, t_json)
 
+    def test_empty_metadata_inconsistent_handling(self):
+        oids = list('bacd')
+        sids = list('YXZ')
+        mat = np.array([[2, 1, 0], [0, 5, 0],
+                        [0, 3, 0], [1, 2, 0]])
+
+        A = Table(mat, oids, sids,
+                  observation_metadata=[{}, {}, {}, {}],
+                  sample_metadata=[{}, {}, {}])
+        B = Table(mat, oids, sids)
+
+        self.assertEqual(A, B)
 
 legacy_otu_table1 = """# some comment goes here
 #OTU ID	Fing	Key	NA	Consensus Lineage


### PR DESCRIPTION
Fixes #594. If a `Table` is created with a list of empty metadata, e.g., `[{}, {}, {}]`, the constructor will set the private metadata attribute to `None`. 