### PR TITLE
clarified docstring for parse_biom_table, addresses #776

### DIFF
--- a/biom/parse.py
+++ b/biom/parse.py
@@ -347,7 +347,7 @@ def parse_biom_table(file_obj, ids=None, axis='sample', input_is_dense=False):
     Parameters
     ----------
     file_obj : file-like object, or list
-        file-like object storing the BIOM table (tab-delimited or JSON), or 
+        file-like object storing the BIOM table (tab-delimited or JSON), or
         a list of lines of the BIOM table in tab-delimited or JSON format
     ids : iterable
         The sample/observation ids of the samples/observations that we need
@@ -406,7 +406,8 @@ def parse_biom_table(file_obj, ids=None, axis='sample', input_is_dense=False):
             c = file_obj.read(1)
         if c == '{':
             file_obj.seek(old_pos)
-            t = Table.from_json(json.load(file_obj, object_pairs_hook=OrderedDict),
+            t = Table.from_json(json.load(file_obj,
+                                          object_pairs_hook=OrderedDict),
                                 input_is_dense=input_is_dense)
         else:
             file_obj.seek(old_pos)
@@ -419,7 +420,8 @@ def parse_biom_table(file_obj, ids=None, axis='sample', input_is_dense=False):
         except ValueError:
             t = Table.from_tsv(file_obj, None, None, lambda x: x)
     else:
-        t = Table.from_json(json.loads(file_obj, object_pairs_hook=OrderedDict),
+        t = Table.from_json(json.loads(file_obj,
+                                       object_pairs_hook=OrderedDict),
                             input_is_dense=input_is_dense)
 
     def subset_ids(data, id_, md):
@@ -662,4 +664,3 @@ def load_table(f):
         except (IndexError, TypeError):
             raise TypeError("%s does not appear to be a BIOM file!" % f)
     return table
-

--- a/biom/parse.py
+++ b/biom/parse.py
@@ -341,13 +341,14 @@ def parse_uc(fh):
     return Table(data, observation_ids=observation_ids, sample_ids=sample_ids)
 
 
-def parse_biom_table(fp, ids=None, axis='sample', input_is_dense=False):
-    r"""Parses the biom table stored in the filepath `fp`
+def parse_biom_table(file_obj, ids=None, axis='sample', input_is_dense=False):
+    r"""Parses the biom table stored in `file_obj`
 
     Parameters
     ----------
-    fp : file like
-        File alike object storing the BIOM table
+    file_obj : file-like object, or list
+        file-like object storing the BIOM table (tab-delimited or JSON), or 
+        a list of lines of the BIOM table in tab-delimited or JSON format
     ids : iterable
         The sample/observation ids of the samples/observations that we need
         to retrieve from the biom table
@@ -360,7 +361,7 @@ def parse_biom_table(fp, ids=None, axis='sample', input_is_dense=False):
     Returns
     -------
     Table
-        The BIOM table stored at fp
+        The BIOM table stored at file_obj
 
     Raises
     ------
@@ -391,34 +392,34 @@ def parse_biom_table(fp, ids=None, axis='sample', input_is_dense=False):
         UnknownAxisError(axis)
 
     try:
-        return Table.from_hdf5(fp, ids=ids, axis=axis)
+        return Table.from_hdf5(file_obj, ids=ids, axis=axis)
     except ValueError:
         pass
     except RuntimeError:
         pass
-    if hasattr(fp, 'read'):
-        old_pos = fp.tell()
+    if hasattr(file_obj, 'read'):
+        old_pos = file_obj.tell()
         # Read in characters until first non-whitespace
         # If it is a {, then this is (most likely) JSON
-        c = fp.read(1)
+        c = file_obj.read(1)
         while c.isspace():
-            c = fp.read(1)
+            c = file_obj.read(1)
         if c == '{':
-            fp.seek(old_pos)
-            t = Table.from_json(json.load(fp, object_pairs_hook=OrderedDict),
+            file_obj.seek(old_pos)
+            t = Table.from_json(json.load(file_obj, object_pairs_hook=OrderedDict),
                                 input_is_dense=input_is_dense)
         else:
-            fp.seek(old_pos)
-            t = Table.from_tsv(fp, None, None, lambda x: x)
-    elif isinstance(fp, list):
+            file_obj.seek(old_pos)
+            t = Table.from_tsv(file_obj, None, None, lambda x: x)
+    elif isinstance(file_obj, list):
         try:
-            t = Table.from_json(json.loads(''.join(fp),
+            t = Table.from_json(json.loads(''.join(file_obj),
                                            object_pairs_hook=OrderedDict),
                                 input_is_dense=input_is_dense)
         except ValueError:
-            t = Table.from_tsv(fp, None, None, lambda x: x)
+            t = Table.from_tsv(file_obj, None, None, lambda x: x)
     else:
-        t = Table.from_json(json.loads(fp, object_pairs_hook=OrderedDict),
+        t = Table.from_json(json.loads(file_obj, object_pairs_hook=OrderedDict),
                             input_is_dense=input_is_dense)
 
     def subset_ids(data, id_, md):
@@ -661,3 +662,4 @@ def load_table(f):
         except (IndexError, TypeError):
             raise TypeError("%s does not appear to be a BIOM file!" % f)
     return table
+

--- a/biom/table.py
+++ b/biom/table.py
@@ -3252,26 +3252,26 @@ class Table(object):
         alignable_o = self_o == other_o
         alignable_s = self_s == other_s
 
-        if axis is 'both' and not (alignable_o and alignable_s):
+        if axis == 'both' and not (alignable_o and alignable_s):
             raise DisjointIDError("Cannot align both axes")
-        elif axis is 'sample' and not alignable_s:
+        elif axis == 'sample' and not alignable_s:
             raise DisjointIDError("Cannot align samples")
-        elif axis is 'observation' and not alignable_o:
+        elif axis == 'observation' and not alignable_o:
             raise DisjointIDError("Cannot align observations")
-        elif axis is 'detect' and not (alignable_o or alignable_s):
+        elif axis == 'detect' and not (alignable_o or alignable_s):
             raise DisjointIDError("Neither axis appears alignable")
 
-        if axis is 'both':
+        if axis == 'both':
             order = ['observation', 'sample']
-        elif axis is 'detect':
+        elif axis == 'detect':
             order = []
             if alignable_s:
                 order.append('sample')
             if alignable_o:
                 order.append('observation')
-        elif axis is 'sample':
+        elif axis == 'sample':
             order = ['sample']
-        elif axis is 'observation':
+        elif axis == 'observation':
             order = ['observation']
         else:
             raise UnknownAxisError("Unrecognized axis: %s" % axis)
@@ -3506,18 +3506,18 @@ class Table(object):
 
         """
         # determine the sample order in the resulting table
-        if sample is 'union':
+        if sample == 'union':
             new_samp_order = self._union_id_order(self.ids(), other.ids())
-        elif sample is 'intersection':
+        elif sample == 'intersection':
             new_samp_order = self._intersect_id_order(self.ids(), other.ids())
         else:
             raise TableException("Unknown sample merge type: %s" % sample)
 
         # determine the observation order in the resulting table
-        if observation is 'union':
+        if observation == 'union':
             new_obs_order = self._union_id_order(
                 self.ids(axis='observation'), other.ids(axis='observation'))
-        elif observation is 'intersection':
+        elif observation == 'intersection':
             new_obs_order = self._intersect_id_order(
                 self.ids(axis='observation'), other.ids(axis='observation'))
         else:


### PR DESCRIPTION
Addresses #776 

Renamed `fp` to `file_obj` to reduce confusion over acceptable parameter types.

Updated annotation for `file_obj` to clarify acceptable types.