### PR TITLE
feat: allow for direct tsv output with optional progress bar

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -1548,7 +1548,7 @@ class Table(object):
 
     def delimited_self(self, delim=u'\t', header_key=None, header_value=None,
                        metadata_formatter=str,
-                       observation_column_name=u'#OTU ID', direct_io=None):
+                       observation_column_name=u'#OTU ID', direct_io=None, verbose=False):
         """Return self as a string in a delimited form
 
         Default str output for the Table is just row/col ids and table data
@@ -1605,7 +1605,11 @@ class Table(object):
             direct_io.writelines([i+"\n" for i in output])
 
         obs_metadata = self.metadata(axis='observation')
-        for obs_id, obs_values in zip(tqdm.tqdm(self.ids(axis='observation'), total=len(self.ids(axis='observation'))),
+        if verbose:
+            iterable = tqdm.tqdm(self.ids(axis='observation'), total=len(self.ids(axis='observation')))
+        else:
+            iterable = self.ids(axis='observation')
+        for obs_id, obs_values in zip(iterable,
                                       self._iter_obs()):
             str_obs_vals = delim.join(map(str, self._to_dense(obs_values)))
             obs_id = to_utf8(obs_id)
@@ -4809,7 +4813,7 @@ html
         return samp_ids, obs_ids, data, metadata, md_name
 
     def to_tsv(self, header_key=None, header_value=None,
-               metadata_formatter=str, observation_column_name='#OTU ID', direct_io=None):
+               metadata_formatter=str, observation_column_name='#OTU ID', direct_io=None, verbose=False):
         """Return self as a string in tab delimited form
 
         Default ``str`` output for the ``Table`` is just row/col ids and table
@@ -4859,7 +4863,9 @@ html
         """
         return self.delimited_self(u'\t', header_key, header_value,
                                    metadata_formatter,
-                                   observation_column_name, direct_io=direct_io)
+                                   observation_column_name, 
+                                   direct_io=direct_io, 
+                                   verbose=verbose)
 
 
 def coo_arrays_to_sparse(data, dtype=np.float64, shape=None):

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ if USE_CYTHON:
 
 install_requires = ["click", "numpy >= 1.9.2", "future >= 0.16.0",
                     "scipy >= 0.13.0", 'pandas >= 0.20.0',
-                    "six >= 1.10.0"]
+                    "six >= 1.10.0", "tqdm >= 4.32.1"]
 
 # HACK: for backward-compatibility with QIIME 1.9.x, pyqi must be installed.
 # pyqi is not used anymore in this project.


### PR DESCRIPTION
Handling big files is very uncomfortable in current version - converting .biom to tsv requires reading all of the data into memory and only then writing it to file. Now it is possible to do so on-the-fly, with a neat TQDM progress bar (specified by `verbose` parameter)