### PR TITLE
don't strip tabs from header

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -4707,7 +4707,7 @@ html
                 # Covers the case where the first line is the header
                 # and there is no indication of it (no comment character)
                 if not header:
-                    header = line.strip(" ").split(delim)[1:]
+                    header = line.rstrip().split(delim)[1:]
                     data_start = list_index + 1
                 else:
                     data_start = list_index

--- a/biom/table.py
+++ b/biom/table.py
@@ -4707,7 +4707,7 @@ html
                 # Covers the case where the first line is the header
                 # and there is no indication of it (no comment character)
                 if not header:
-                    header = line.strip().split(delim)[1:]
+                    header = line.strip(" ").split(delim)[1:]
                     data_start = list_index + 1
                 else:
                     data_start = list_index


### PR DESCRIPTION
- in tsv data with row and column names the first cell of the   header is usually left empty, e.g. tsv export from R does it   like this
- the content of the 1st cell in the header seems not to appear   in the header anyway, so leaving it unstripped might also be fine
- stripping the leading tab leads to an error:

```
Traceback (most recent call last):
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/bin/biom", line 6, in <module>
    sys.exit(biom.cli.cli())
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/cli/table_converter.py", line 114, in convert
    table = load_table(input_fp)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/parse.py", line 654, in load_table
    table = parse_biom_table(fp)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/parse.py", line 408, in parse_biom_table
    t = Table.from_tsv(fp, None, None, lambda x: x)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/table.py", line 3911, in from_tsv
    return Table(data, obs_ids, sample_ids, obs_metadata, sample_metadata)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/table.py", line 310, in __init__
    shape=shape)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/table.py", line 453, in _to_sparse
    mat = list_list_to_sparse(values, dtype, shape=shape)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/biom_format-2.1.5-py3.6-linux-x86_64.egg/biom/table.py", line 4159, in list_list_to_sparse
    dtype=dtype)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/scipy/sparse/coo.py", line 184, in __init__
    self._check()
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biom-format@2.1.5/lib/python3.6/site-packages/scipy/sparse/coo.py", line 232, in _check
    raise ValueError('column index exceeds matrix dimensions')
ValueError: column index exceeds matrix dimensions
```