### PR TITLE
Export metadata as TSV

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ New Features:
 
 * The detailed report is no longer part of the table validator. See [issue #378](https://github.com/biocore/biom-format/issues/378).
 * `load_table` now accepts open file handles. See [issue #481](https://github.com/biocore/biom-format/issues/481).
+* `biom export-metadata` has been added to export metadata as TSV. See [issue #820](https://github.com/biocore/biom-format/issues/820).
 
 Bug fixes:
 

--- a/biom/cli/__init__.py
+++ b/biom/cli/__init__.py
@@ -30,6 +30,7 @@ def cli(ctx):
 
 import_module('biom.cli.table_summarizer')
 import_module('biom.cli.metadata_adder')
+import_module('biom.cli.metadata_exporter')
 import_module('biom.cli.table_converter')
 import_module('biom.cli.installation_informer')
 import_module('biom.cli.table_subsetter')

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -36,9 +36,10 @@ def export_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
     table = load_table(input_fp)
 
     if sample_metadata_fp:
-        _export_metadata(table, 'sample', input_fp, sample_metadata_fp)
+        _export_metadata(table, 'sample', input_fp,sample_metadata_fp)
     if observation_metadata_fp:
-        _export_metadata(table, 'observation', input_fp, observation_metadata_fp)
+        _export_metadata(table, 'observation', input_fp,
+                         observation_metadata_fp)
 
 
 def _export_metadata(table, axis, input_fp, output_fp):
@@ -46,4 +47,5 @@ def _export_metadata(table, axis, input_fp, output_fp):
         metadata = table.metadata_to_dataframe(axis)
         metadata.to_csv(output_fp, sep='\t')
     except KeyError:
-        click.echo('File {} does not contain {} metadata'.format(input_fp, axis))
+        click.echo('File {} does not contain {} metadata'.format(input_fp,
+                                                                 axis))

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -36,14 +36,14 @@ def export_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
     table = load_table(input_fp)
 
     if sample_metadata_fp:
-        _export_metadata(table, 'sample', sample_metadata_fp)
+        _export_metadata(table, 'sample', input_fp, sample_metadata_fp)
     if observation_metadata_fp:
-        _export_metadata(table, 'observation', observation_metadata_fp)
+        _export_metadata(table, 'observation', input_fp, observation_metadata_fp)
 
 
-def _export_metadata(table, axis, output_fp):
+def _export_metadata(table, axis, input_fp, output_fp):
     try:
         metadata = table.metadata_to_dataframe(axis)
         metadata.to_csv(output_fp, sep='\t')
     except KeyError:
-        click.echo(f'File {output_fp} does not contain {axis} metadata')
+        click.echo('File {} does not contain {} metadata'.format(input_fp, axis))

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -22,7 +22,7 @@ from biom.cli import cli
 @click.option('--observation-metadata-fp', required=False,
               type=click.Path(exists=False, dir_okay=False),
               help='The observation metadata output file.')
-def add_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
+def export_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
     """Export metadata as TSV.
 
     Example usage:
@@ -34,10 +34,15 @@ def add_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
       --observation-metadata-fp observation.tsv
     """
     table = load_table(input_fp)
-    sample_metadata = table.metadata_to_dataframe('sample')
-    observation_metadata = table.metadata_to_dataframe('observation')
 
     if sample_metadata_fp:
-        sample_metadata.to_csv(sample_metadata_fp, sep='\t')
+        _export_metadata(table, 'sample', sample_metadata_fp)
     if observation_metadata_fp:
-        observation_metadata.to_csv(observation_metadata_fp, sep='\t')
+        _export_metadata(table, 'observation', observation_metadata_fp)
+
+def _export_metadata(table, axis, output_fp):
+    try:
+        metadata = table.metadata_to_dataframe(axis)
+        metadata.to_csv(output_fp, sep='\t')
+    except KeyError:
+        click.echo(f'File {output_fp} does not contain {axis} metadata')

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -36,7 +36,7 @@ def export_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
     table = load_table(input_fp)
 
     if sample_metadata_fp:
-        _export_metadata(table, 'sample', input_fp,sample_metadata_fp)
+        _export_metadata(table, 'sample', input_fp, sample_metadata_fp)
     if observation_metadata_fp:
         _export_metadata(table, 'observation', input_fp,
                          observation_metadata_fp)

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2011-2017, The BIOM Format Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+import click
+
+from biom import load_table
+from biom.cli import cli
+
+
+@cli.command(name='export-metadata')
+@click.option('-i', '--input-fp', required=True,
+              type=click.Path(exists=True, dir_okay=False),
+              help='The input BIOM table')
+@click.option('-m', '--sample-metadata-fp', required=False,
+              type=click.Path(exists=False, dir_okay=False),
+              help='The sample metadata output file.')
+@click.option('--observation-metadata-fp', required=False,
+              type=click.Path(exists=False, dir_okay=False),
+              help='The observation metadata output file.')
+def add_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
+    """Export metadata as TSV.
+
+    Example usage:
+
+    Export metadata as TSV:
+
+    $ biom export-metadata -i otu_table.biom
+      --sample-metadata-fp sample.tsv
+      --observation-metadata-fp observation.tsv
+    """
+    table = load_table(input_fp)
+    sample_metadata = table.metadata_to_dataframe('sample')
+    observation_metadata = table.metadata_to_dataframe('observation')
+
+    if sample_metadata_fp:
+        sample_metadata.to_csv(sample_metadata_fp, sep='\t')
+    if observation_metadata_fp:
+        observation_metadata.to_csv(observation_metadata_fp, sep='\t')

--- a/biom/cli/metadata_exporter.py
+++ b/biom/cli/metadata_exporter.py
@@ -40,6 +40,7 @@ def export_metadata(input_fp, sample_metadata_fp, observation_metadata_fp):
     if observation_metadata_fp:
         _export_metadata(table, 'observation', observation_metadata_fp)
 
+
 def _export_metadata(table, axis, output_fp):
     try:
         metadata = table.metadata_to_dataframe(axis)


### PR DESCRIPTION
This pull request addresses https://github.com/biocore/biom-format/issues/820 by wrapping `Table.metadata_to_dataframe()` in a CLI method `biom export-metadata`.

Example usage:

```
biom add-metadata -i ./biom-format/examples/min_sparse_otu_table_hdf5.biom -o ./test.biom --observation-metadata-fp ./biom-format/examples/obs_md.txt --sample-metadata-fp ./biom-format/examples/sam_md.txt
biom export-metadata -i ./test.biom --sample-metadata-fp ./metadata_sample.tsv --observation-metadata-fp ./metadata_observation.tsv
```