### PR TITLE
Make to_dataframe use the new Sparse data structures from pandas >= 0.25

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -178,7 +178,7 @@ import scipy.stats
 from copy import deepcopy
 from datetime import datetime
 from json import dumps
-from functools import reduce, partial
+from functools import reduce
 from operator import itemgetter
 from future.builtins import zip
 from future.utils import viewitems
@@ -4027,16 +4027,19 @@ html
         return t
 
     def to_dataframe(self, dense=False):
-        """Convert matrix data to a Pandas SparseDataFrame or DataFrame
+        """Convert matrix data to a Pandas DataFrame
 
         Parameters
         ----------
         dense : bool, optional
-            If True, return pd.DataFrame instead of pd.SparseDataFrame.
+            If True, return a DataFrame that doesn't use sparse arrays
+            internally.
+            The default behavior (if dense is False) is to return a DataFrame
+            that uses sparse arrays.
 
         Returns
         -------
-        pd.DataFrame or pd.SparseDataFrame
+        pd.DataFrame
             A DataFrame indexed on the observation IDs, with the column
             names as the sample IDs.
 
@@ -4061,9 +4064,7 @@ html
             constructor = pd.DataFrame
         else:
             mat = self.matrix_data
-            constructor = partial(pd.SparseDataFrame,
-                                  default_fill_value=0,
-                                  copy=True)
+            constructor = pd.DataFrame.sparse.from_spmatrix
 
         return constructor(mat, index=index, columns=columns)
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1500,8 +1500,8 @@ class TableTests(TestCase):
         # Make a 1 million x 1 million table, where the only entries are on the
         # diagonal. Stored dense, this would have 1 trillion entries, so it'd
         # explode most computers (or at least take a lot of memory to use);
-        # stored dense, this should only require enough memory to keep track of
-        # the 1 million entries along the diagonal.
+        # stored sparse, this should only require enough memory to keep track
+        # of the 1 million entries along the diagonal.
         def _make_big_table_and_try_conversion():
             mil = 1000000
             big_csr_diag_1s = csr_matrix((mil, mil), dtype="float")

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1473,10 +1473,12 @@ class TableTests(TestCase):
              'tree': ('newick', '((4:0.1,5:0.1):0.2,(6:0.1,7:0.1):0.2):0.3;')})
 
     def test_to_dataframe(self):
-        exp = pd.SparseDataFrame(np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
-                                 index=['O1', 'O2'],
-                                 columns=['S1', 'S2', 'S3'],
-                                 default_fill_value=0.0)
+        # re: SparseDtype -- see section on "Sparse data structures" at
+        # https://pandas.pydata.org/pandas-docs/stable/user_guide/sparse.html
+        exp = pd.DataFrame(np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
+                           index=['O1', 'O2'],
+                           columns=['S1', 'S2', 'S3'],
+                           dtype=pd.SparseDtype("float", 0.0))
         obs = example_table.to_dataframe()
         pdt.assert_frame_equal(obs, exp)
 
@@ -1484,7 +1486,7 @@ class TableTests(TestCase):
         df = example_table.to_dataframe()
         density = (float(example_table.matrix_data.getnnz()) /
                    np.prod(example_table.shape))
-        assert np.allclose(df.density, density)
+        assert np.allclose(df.sparse.density, density)
 
     def test_to_dataframe_dense(self):
         exp = pd.DataFrame(np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ extensions = [Extension("biom._filter",
 extensions = cythonize(extensions)
 
 install_requires = ["click", "numpy >= 1.9.2", "future >= 0.16.0",
-                    "scipy >= 1.3.1", 'pandas >= 0.20.0',
+                    "scipy >= 1.3.1", 'pandas >= 0.25.0',
                     "six >= 1.10.0", "cython >= 0.29", "h5py",
                     "cython"]
 


### PR DESCRIPTION
Currently, pandas v1 is the reason folks are running into problems like #837. This is also breaking a couple of other packages that rely on biom, including but probably not limited to [songbird](https://github.com/biocore/songbird/issues/117) and [mmvec](https://github.com/biocore/mmvec/issues/123).

This PR should fix the problem for _most_ datasets. However, **there are a few complicating factors that I think will prevent merging this PR in right now**, both due to [`pd.DataFrame.sparse.from_spmatrix()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sparse.from_spmatrix.html) (which is pandas' recommended way to convert SciPy CSR matrices to DataFrames-with-sparse-values):

1. ~~I'm pretty sure `from_spmatrix()` doesn't handle the sparse data in these matrices properly. When I make a huge but super sparse matrix in SciPy and try to convert it to a DF, my computer explodes at the conversion step (even though initializing the matrix takes on the order of 15-ish seconds for SciPy). I've opened https://github.com/pandas-dev/pandas/issues/32196 accordingly.~~ **Update:** this assumption was incorrect on my part, and it's expected that really wide matrices like this really will slow down pandas. See the pandas issue thread linked for profiling details / their response.

   To ensure that this change doesn't cause a repeat of #808, I added a test in this PR that makes sure that these sorts of large matrices can be converted to sparse DataFrames in a sane amount of time (max 30 seconds). This currently fails, since `biom.table.Table.to_dataframe()` in this PR uses `from_spmatrix()` under the hood. Making `to_dataframe()` faster should cause this test to pass. (If I'm being overzealous and sparse DataFrames are really going to be slower to create than I'd thought, it's totally possible to bump up the 30-second timer in this test.) **Update:** will need to do this and/or just try a less crazy sparse matrix than a 1mil x 1mil one.

2. ...Also I think `from_spmatrix()` has [other bugs](https://github.com/pandas-dev/pandas/issues/28992) that might make it unreliable.

ANYWAY TLDR hopefully these changes are useful at least as a starting point for a solution to this problem. Thanks!