### PR TITLE
Numpy and Cython as build dependencies, PEP518

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@ New changes since 2.1.8 go here.
 
 Important:
 
+* Cython and numpy are no more required to be present before building, see [PR #840](https://github.com/biocore/biom-format/pull/840)
+
 New Features:
 
 Bug fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools","wheel", "numpy", "cython"]

--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,8 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.test import test as TestCommand
-
-try:
-    import numpy as np
-except ImportError:
-    raise ImportError("numpy must be installed prior to installing biom")
-
-
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    raise ImportError("cython must be installed prior to installing biom")
-
+import numpy as np
+from Cython.Build import cythonize
 
 # Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
 # in multiprocessing/util.py _exit_function when running `python


### PR DESCRIPTION
`biom-format` now requires that `numpy` and `cython` should be present in the build environment prior the builing.
By implementing the PEP518, 
https://github.com/biocore/biom-format/blob/fd84172794d14a741a5764234d7a28416b9dba08/setup.py#L18-L21 and https://github.com/biocore/biom-format/blob/fd84172794d14a741a5764234d7a28416b9dba08/setup.py#L24-L27 are not longer required.

Also, this PR resolves the issue of having `biom-format` in `install_requires` installed before `cython`, which leads to a failure

```python
    Complete output (12 lines):
    Traceback (most recent call last):
      File "/tmp/pip-install-hani473s/biom-format/setup.py", line 25, in <module>
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-hani473s/biom-format/setup.py", line 27, in <module>
        raise ImportError("cython must be installed prior to installing biom")
    ImportError: cython must be installed prior to installing biom
```