### PR TITLE
Fast merge

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@ Important:
 
 New Features:
 
+* A much faster way to merge tables (without metadata) has been added. For large tables, this was a few minutes rather than a few hours. This method is implicitly invoked when calling `Table.merge` if unioning both axes, and the tables lack metadata. `Table.concat` is still much faster, but assumes one axis is disjoint. See [PR #848](https://github.com/biocore/biom-format/pull/848).
+
 Bug fixes:
 
 biom 2.1.8

--- a/biom/table.py
+++ b/biom/table.py
@@ -3584,7 +3584,11 @@ class Table(object):
         """
         s_md = self.metadata()
         o_md = self.metadata(axis='observation')
-        if s_md is None and o_md is None:
+        no_md = (s_md is None) and (o_md is None)
+        ignore_md = (sample_metadata_f == None) and \
+                (observation_metadata_f == None)
+
+        if no_md or ignore_md:
             if sample == 'union' and observation == 'union':
                 if isinstance(other, (list, set, tuple)):
                     return self._fast_merge(other)

--- a/biom/table.py
+++ b/biom/table.py
@@ -3585,8 +3585,8 @@ class Table(object):
         s_md = self.metadata()
         o_md = self.metadata(axis='observation')
         no_md = (s_md is None) and (o_md is None)
-        ignore_md = (sample_metadata_f == None) and \
-                (observation_metadata_f == None)
+        ignore_md = (sample_metadata_f is None) and \
+                (observation_metadata_f is None)
 
         if no_md or ignore_md:
             if sample == 'union' and observation == 'union':

--- a/biom/table.py
+++ b/biom/table.py
@@ -4135,10 +4135,8 @@ html
             mat = self.matrix_data.toarray()
             constructor = pd.DataFrame
         else:
-            mat = self.matrix_data
-            constructor = partial(pd.SparseDataFrame,
-                                  default_fill_value=0,
-                                  copy=True)
+            mat = self.matrix_data.copy()
+            constructor = partial(pd.DataFrame.sparse.from_spmatrix)
 
         return constructor(mat, index=index, columns=columns)
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -3586,7 +3586,7 @@ class Table(object):
         o_md = self.metadata(axis='observation')
         no_md = (s_md is None) and (o_md is None)
         ignore_md = (sample_metadata_f is None) and \
-                (observation_metadata_f is None)
+            (observation_metadata_f is None)
 
         if no_md or ignore_md:
             if sample == 'union' and observation == 'union':

--- a/biom/table.py
+++ b/biom/table.py
@@ -3553,6 +3553,8 @@ class Table(object):
 
         Notes
         -----
+        - If ``sample_metadata_f`` and ``observation_metadata_f`` are None,
+            then a fast merge is applied.
         - There is an implicit type conversion to ``float``.
         - The return type is always that of ``self``
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -2265,7 +2265,7 @@ class SparseTableTests(TestCase):
     def test_fast_merge(self):
         data = {(0, 0): 10, (0, 1): 12, (1, 0): 14, (1, 1): 16}
         exp = Table(data, ['1', '2'], ['a', 'b'])
-        obs = self.st1._fast_merge(self.st1)
+        obs = self.st1._fast_merge([self.st1])
         self.assertEqual(obs, exp)
 
     def test_fast_merge_multiple(self):
@@ -2283,7 +2283,7 @@ class SparseTableTests(TestCase):
                               [7, 8, 0],
                               [0, 8, 7]]), ['1', '2', '3'],
                     ['a', 'b', 'd'])
-        obs = t2._fast_merge(self.st1)
+        obs = t2._fast_merge([self.st1])
         self.assertEqual(obs, exp)
 
     def test_merge(self):

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -2262,6 +2262,30 @@ class SparseTableTests(TestCase):
         npt.assert_equal(obs_obs, exp_obs)
         npt.assert_equal(obs_whole, exp_whole)
 
+    def test_fast_merge(self):
+        data = {(0, 0): 10, (0, 1): 12, (1, 0): 14, (1, 1): 16}
+        exp = Table(data, ['1', '2'], ['a', 'b'])
+        obs = self.st1._fast_merge(self.st1)
+        self.assertEqual(obs, exp)
+
+    def test_fast_merge_multiple(self):
+        data = {(0, 0): 20, (0, 1): 24, (1, 0): 28, (1, 1): 32}
+        exp = Table(data, ['1', '2'], ['a', 'b'])
+        obs = self.st1._fast_merge([self.st1, self.st1, self.st1])
+        self.assertEqual(obs, exp)
+
+    def test_fast_merge_nonoverlapping(self):
+        t2 = self.st1.copy()
+        t2.update_ids({'a': 'd'}, inplace=True, strict=False)
+        t2.update_ids({'2': '3'}, axis='observation', inplace=True,
+                      strict=False)
+        exp = Table(np.array([[5, 12, 5],
+                              [7, 8, 0],
+                              [0, 8, 7]]), ['1', '2', '3'],
+                    ['a', 'b', 'd'])
+        obs = t2._fast_merge(self.st1)
+        self.assertEqual(obs, exp)
+
     def test_merge(self):
         """Merge two tables"""
         u = 'union'

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1473,10 +1473,11 @@ class TableTests(TestCase):
              'tree': ('newick', '((4:0.1,5:0.1):0.2,(6:0.1,7:0.1):0.2):0.3;')})
 
     def test_to_dataframe(self):
-        exp = pd.SparseDataFrame(np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),
-                                 index=['O1', 'O2'],
-                                 columns=['S1', 'S2', 'S3'],
-                                 default_fill_value=0.0)
+        mat = csr_matrix(np.array([[0.0, 1.0, 2.0],
+                                   [3.0, 4.0, 5.0]]))
+        exp = pd.DataFrame.sparse.from_spmatrix(mat,
+                                                index=['O1', 'O2'],
+                                                columns=['S1', 'S2', 'S3'])
         obs = example_table.to_dataframe()
 
         # assert frame equal between sparse and dense frames wasn't working

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1478,13 +1478,19 @@ class TableTests(TestCase):
                                  columns=['S1', 'S2', 'S3'],
                                  default_fill_value=0.0)
         obs = example_table.to_dataframe()
-        pdt.assert_frame_equal(obs, exp)
+
+        # assert frame equal between sparse and dense frames wasn't working
+        # as expected
+        npt.assert_equal(obs.values, exp.values)
+        self.assertTrue(all(obs.index == exp.index))
+        self.assertTrue(all(obs.columns == exp.columns))
 
     def test_to_dataframe_is_sparse(self):
         df = example_table.to_dataframe()
         density = (float(example_table.matrix_data.getnnz()) /
                    np.prod(example_table.shape))
-        assert np.allclose(df.density, density)
+        df_density = (df > 0).sum().sum() / np.prod(df.shape)
+        assert np.allclose(df_density, density)
 
     def test_to_dataframe_dense(self):
         exp = pd.DataFrame(np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]),

--- a/biom/util.py
+++ b/biom/util.py
@@ -202,9 +202,9 @@ def prefer_self(x, y):
     return x if x is not None else y
 
 
-def index_list(l):
+def index_list(item):
     """Takes a list and returns {l[idx]:idx}"""
-    return dict([(id_, idx) for idx, id_ in enumerate(l)])
+    return dict([(id_, idx) for idx, id_ in enumerate(item)])
 
 
 def load_biom_config():


### PR DESCRIPTION
Added a (much) faster way to merge tables when the axes overlap. `Table.concat` is still (much) faster for the special case where one axis is assured to be disjoint. This revised merge method can operate on many tables at once, unlike the existing `merge` which took a single table. 

I don't have exact timing information, but the existing merge with four tables, each with roughly 600 samples and 1M features, was around 3 hours. This new method took a few minutes.