### PR TITLE
fix #770 date keyword in Python >= 3.7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 BIOM-Format ChangeLog
 =====================
 
+biom 2.1.11
+
+Bug fix, release pending
+
+Bug fixes:
+
+* `Table.from_json` now respects the creation date [issue #770](https://github.com/biocore/biom-format/issues/770) in Python 3.7 and higher
+
 biom 2.1.10
 -----------
 
@@ -83,6 +91,7 @@ Bug fixes:
 * `Table.subsample(by_id=True, axis='observation')` did not subsample over the 'observations'. Because of the nature of the bug, an empty table was returned, so the scope of the issue is such that it should not have produced misleading results but instead triggered empty table errors, with the exception of the pathological case of the ID namespaces between features and samples not being disjoint. See [PR #759](https://github.com/biocore/biom-format/pull/759) for more information.
 * Tables of shape `(0, n)` or `(n, 0)` were raising exceptions when being written out. See [issue #619](https://github.com/biocore/biom-format/issues/619).
 * Tables loaded with a `list` of empty `dict`s will have their metadata attributes set to None. See [issue #594](https://github.com/biocore/biom-format/issues/594).
+
 
 biom 2.1.6
 ----------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,8 @@
 BIOM-Format ChangeLog
 =====================
 
-biom 2.1.11
-
-Bug fix, release pending
+biom 2.1.11-dev
+-----------
 
 Bug fixes:
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -4562,21 +4562,23 @@ html
         type_ = json_table['type']
 
         if data_pump is None:
-            table_obj = Table(json_table['data'], obs_ids, sample_ids,
-                              obs_metadata, sample_metadata,
-                              shape=json_table['shape'],
-                              dtype=dtype,
-                              type=type_,
-                              generated_by=json_table['generated_by'],
-                              input_is_dense=input_is_dense)
+            data = json_table['data']
         else:
-            table_obj = Table(data_pump, obs_ids, sample_ids,
-                              obs_metadata, sample_metadata,
-                              shape=json_table['shape'],
-                              dtype=dtype,
-                              type=type_,
-                              generated_by=json_table['generated_by'],
-                              input_is_dense=input_is_dense)
+            data = data_pump
+        create_date = None
+        if hasattr(datetime, "fromisoformat"):
+            try:
+                create_date = datetime.fromisoformat(json_table['date'])
+            except (TypeError, ValueError):
+                pass
+        table_obj = Table(data, obs_ids, sample_ids,
+                          obs_metadata, sample_metadata,
+                          shape=json_table['shape'],
+                          dtype=dtype,
+                          type=type_,
+                          create_date=create_date,
+                          generated_by=json_table['generated_by'],
+                          input_is_dense=input_is_dense)
         return table_obj
 
     def to_json(self, generated_by, direct_io=None):


### PR DESCRIPTION
This is a revamp of #771 without adding external dependencies.