### PR TITLE
Align methods for #858

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,10 +1,10 @@
 name: biom-format CI
 
-on: 
+on:
   push:
     branches: [ master ]
   pull_request:
-    
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
       run: |
         pip install -q flake8
         flake8 biom setup.py
-        
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -28,21 +28,21 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.7   
+        python-version: 3.7
     - name: Install dependencies
       shell: bash -l {0}
       run: |
         conda create --yes -n env_name python=3.7
         conda activate env_name
-        conda install --name env_name pip click numpy "scipy>=1.3.1" pep8 flake8 coverage future six "pandas>=0.20.0" nose h5py>=2.2.0 cython
+        conda install --name env_name pip click numpy "scipy>=1.3.1" pep8 flake8 coverage future six "pandas>=0.20.0" nose h5py>=2.2.0 cython scikit-bio
         pip install sphinx==1.2.2 "docutils<0.14"
         pip install -e . --no-deps
-    - name: Build docs      
+    - name: Build docs
       shell: bash -l {0}
       run: |
         conda activate env_name
         make -C doc html
-        
+
   build:
     strategy:
       matrix:
@@ -63,13 +63,13 @@ jobs:
         conda activate env_name
         conda install -y pip click numpy "scipy>=1.3.1" pep8 flake8 coverage future six "pandas>=0.20.0" nose h5py>=2.2.0 cython
         pip install anndata
-        
+
     - name: Tests
       shell: bash -l {0}
       run: |
         conda activate env_name
         conda install -y pytest
-        which python 
+        which python
         pip install -e . --no-deps
         make test
         biom show-install-info

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         conda create --yes -n env_name python=${{ matrix.python-version }}
         conda activate env_name
-        conda install -y pip click numpy "scipy>=1.3.1" pep8 flake8 coverage future six "pandas>=0.20.0" nose h5py>=2.2.0 cython
+        conda install -y pip click numpy "scipy>=1.3.1" pep8 flake8 coverage future six "pandas>=0.20.0" nose h5py>=2.2.0 cython scikit-bio
         pip install anndata
 
     - name: Tests

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,10 @@ biom 2.1.11-dev
 
 Bug fixes:
 
-* `Table.from_json` now respects the creation date [issue #770](https://github.com/biocore/biom-format/issues/770) in Python 3.7 and higher
+	* `Table.from_json` now respects the creation date [issue #770](https://github.com/biocore/biom-format/issues/770) in Python 3.7 and higher
+
+New Features
+* Added support for aligning dataframes and trees against biom tables with `Table.align_to_dataframe` and `Table.align_tree`.  see [PR #859](https://github.com/biocore/biom-format/pull/859)
 
 biom 2.1.10
 -----------
@@ -33,7 +36,7 @@ New Features:
 * A much faster way to merge tables (without metadata) has been added. For large tables, this was a few minutes rather than a few hours. This method is implicitly invoked when calling `Table.merge` if unioning both axes, and the tables lack metadata. `Table.concat` is still much faster, but assumes one axis is disjoint. See [PR #848](https://github.com/biocore/biom-format/pull/848).
 
 * Simplify interaction with the concatenation method, allowing for passing in an individual table and support for a general `biom.concat(tables)` wrapper. See [PR #851](https://github.com/biocore/biom-format/pull/851).
-* Added support for parsing adjacency table structures, see [issue #823](https://github.com/biocore/biom-format/issues/823). 
+* Added support for parsing adjacency table structures, see [issue #823](https://github.com/biocore/biom-format/issues/823).
 
 Bug fixes:
 
@@ -47,7 +50,7 @@ New features and bug fixes, released on 28 January 2020.
 Important:
 
 * Python 2.7 and 3.5 support has been dropped.
-* Python 3.8 support has been added into Travis CI. 
+* Python 3.8 support has been added into Travis CI.
 * A change to the defaults for `Table.nonzero_counts` was performed such that the default now is to count the number of nonzero features. See [issue #685](https://github.com/biocore/biom-format/issues/685)
 * We now require a SciPy >= 1.3.1. See [issue #816](https://github.com/biocore/biom-format/issues/816)
 
@@ -403,42 +406,42 @@ Changes:
 * [pyqi](http://bipy.github.io/pyqi) 0.2.0 is now a required dependency. This changes the look-and-feel of the biom-format command-line interfaces and introduces a new executable, ```biom```, which can be used to see a list of all available biom-format command-line commands. The ```biom``` command is now used to run biom-format commands, instead of having a Python script (i.e., .py file) for each biom-format command. The old scripts (e.g., add_metadata.py, convert_biom.py, etc.) are still included but are deprecated. Users are pointed to the new ```biom``` command to run instead. Bash tab completion is now supported for all command and option names (see the biom-format documentation for instructions on how to enable this).
 * The following scripts have had their names and options changed:
     * ```add_metadata.py``` is now ```biom add-metadata```. Changed option names:
-        * ```--input_fp``` is now ```--input-fp```
-        * ```--output_fp``` is now ```--output-fp```
-        * ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
-        * ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
-        * ```--sc_separated``` is now ```--sc-separated```
-        * ```--int_fields``` is now ```--int-fields```
-        * ```--float_fields``` is now ```--float-fields```
-        * ```--sample_header``` is now ```--sample-header```
-        * ```--observation_header``` is now ```--observation-header```
-        * New option ```--sc-pipe-separated```
+	* ```--input_fp``` is now ```--input-fp```
+	* ```--output_fp``` is now ```--output-fp```
+	* ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
+	* ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
+	* ```--sc_separated``` is now ```--sc-separated```
+	* ```--int_fields``` is now ```--int-fields```
+	* ```--float_fields``` is now ```--float-fields```
+	* ```--sample_header``` is now ```--sample-header```
+	* ```--observation_header``` is now ```--observation-header```
+	* New option ```--sc-pipe-separated```
     * ```biom_validator.py``` is now ```biom validate-table```. Changed option names:
-        * ```-v```/```--verbose``` is now ```--detailed-report```
-        * ```--biom_fp``` is now ```--input-fp```
+	* ```-v```/```--verbose``` is now ```--detailed-report```
+	* ```--biom_fp``` is now ```--input-fp```
     * ```convert_biom.py``` is now ```biom convert```. Changed option names:
-        * ```--input_fp``` is now ```--input-fp```
-        * ```--output_fp``` is now ```--output-fp```
-        * ```--biom_type``` is now ```--matrix-type```
-        * ```--biom_to_classic_table``` is now ```--biom-to-classic-table```
-        * ```--sparse_biom_to_dense_biom``` is now ```--sparse-biom-to-dense-biom```
-        * ```--dense_biom_to_sparse_biom``` is now ```--dense-biom-to-sparse-biom```
-        * ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
-        * ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
-        * ```--header_key``` is now ```--header-key```
-        * ```--output_metadata_id``` is now ```--output-metadata-id```
-        * ```--process_obs_metadata``` is now ```--process-obs-metadata```
-        * ```--biom_table_type``` is now ```--table-type```
+	* ```--input_fp``` is now ```--input-fp```
+	* ```--output_fp``` is now ```--output-fp```
+	* ```--biom_type``` is now ```--matrix-type```
+	* ```--biom_to_classic_table``` is now ```--biom-to-classic-table```
+	* ```--sparse_biom_to_dense_biom``` is now ```--sparse-biom-to-dense-biom```
+	* ```--dense_biom_to_sparse_biom``` is now ```--dense-biom-to-sparse-biom```
+	* ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
+	* ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
+	* ```--header_key``` is now ```--header-key```
+	* ```--output_metadata_id``` is now ```--output-metadata-id```
+	* ```--process_obs_metadata``` is now ```--process-obs-metadata```
+	* ```--biom_table_type``` is now ```--table-type```
     * ```print_biom_python_config.py``` is now ```biom show-install-info```.
     * ```print_biom_table_summary.py``` is now ```biom summarize-table```. Changed option names:
-        * ```--input_fp``` is now ```--input-fp```
-        * ```--output_fp``` is now ```--output-fp```. This is now a required option (output is no longer printed to stdout).
-        * ```--num_observations``` is now ```--qualitative```
-        * ```--suppress_md5``` is now ```--suppress-md5```
+	* ```--input_fp``` is now ```--input-fp```
+	* ```--output_fp``` is now ```--output-fp```. This is now a required option (output is no longer printed to stdout).
+	* ```--num_observations``` is now ```--qualitative```
+	* ```--suppress_md5``` is now ```--suppress-md5```
     * ```subset_biom.py``` is now ```biom subset-table```. Changed option names:
-        * ```--biom_fp``` is now ```--input-fp```
-        * ```--output_fp``` is now ```--output-fp```
-        * ```--ids_fp``` is now ```--ids```
+	* ```--biom_fp``` is now ```--input-fp```
+	* ```--output_fp``` is now ```--output-fp```
+	* ```--ids_fp``` is now ```--ids```
 * ```biom.parse.parse_mapping``` has been replaced by ```biom.parse.MetadataMap```. ```biom.parse.MetadataMap.from_file``` can be directly substituted in place of ```biom.parse.parse_mapping```.
 
 Bug Fixes:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,10 +6,7 @@ biom 2.1.11-dev
 
 Bug fixes:
 
-	* `Table.from_json` now respects the creation date [issue #770](https://github.com/biocore/biom-format/issues/770) in Python 3.7 and higher
-
-New Features
-* Added support for aligning dataframes and trees against biom tables with `Table.align_to_dataframe` and `Table.align_tree`.  see [PR #859](https://github.com/biocore/biom-format/pull/859)
+* `Table.from_json` now respects the creation date [issue #770](https://github.com/biocore/biom-format/issues/770) in Python 3.7 and higher
 
 biom 2.1.10
 -----------
@@ -19,6 +16,10 @@ Bug fix, released on 16 November 2020.
 Bug fixes:
 
 * During deployment testing for QIIME 2 2020.11, it was observed that certain combinations of hdf5 or h5py dependencies can result in metadata strings parsing as ASCII rather than UTF-8. Parse of BIOM-Format 2.1.0 files now normalize metadata strings as UTF-8, see [PR #853](https://github.com/biocore/biom-format/pull/853).
+
+New Features
+
+* Added support for aligning dataframes and trees against biom tables with `Table.align_to_dataframe` and `Table.align_tree`.  see [PR #859](https://github.com/biocore/biom-format/pull/859)
 
 biom 2.1.9
 ----------
@@ -36,7 +37,7 @@ New Features:
 * A much faster way to merge tables (without metadata) has been added. For large tables, this was a few minutes rather than a few hours. This method is implicitly invoked when calling `Table.merge` if unioning both axes, and the tables lack metadata. `Table.concat` is still much faster, but assumes one axis is disjoint. See [PR #848](https://github.com/biocore/biom-format/pull/848).
 
 * Simplify interaction with the concatenation method, allowing for passing in an individual table and support for a general `biom.concat(tables)` wrapper. See [PR #851](https://github.com/biocore/biom-format/pull/851).
-* Added support for parsing adjacency table structures, see [issue #823](https://github.com/biocore/biom-format/issues/823).
+* Added support for parsing adjacency table structures, see [issue #823](https://github.com/biocore/biom-format/issues/823). 
 
 Bug fixes:
 
@@ -50,7 +51,7 @@ New features and bug fixes, released on 28 January 2020.
 Important:
 
 * Python 2.7 and 3.5 support has been dropped.
-* Python 3.8 support has been added into Travis CI.
+* Python 3.8 support has been added into Travis CI. 
 * A change to the defaults for `Table.nonzero_counts` was performed such that the default now is to count the number of nonzero features. See [issue #685](https://github.com/biocore/biom-format/issues/685)
 * We now require a SciPy >= 1.3.1. See [issue #816](https://github.com/biocore/biom-format/issues/816)
 
@@ -406,42 +407,42 @@ Changes:
 * [pyqi](http://bipy.github.io/pyqi) 0.2.0 is now a required dependency. This changes the look-and-feel of the biom-format command-line interfaces and introduces a new executable, ```biom```, which can be used to see a list of all available biom-format command-line commands. The ```biom``` command is now used to run biom-format commands, instead of having a Python script (i.e., .py file) for each biom-format command. The old scripts (e.g., add_metadata.py, convert_biom.py, etc.) are still included but are deprecated. Users are pointed to the new ```biom``` command to run instead. Bash tab completion is now supported for all command and option names (see the biom-format documentation for instructions on how to enable this).
 * The following scripts have had their names and options changed:
     * ```add_metadata.py``` is now ```biom add-metadata```. Changed option names:
-	* ```--input_fp``` is now ```--input-fp```
-	* ```--output_fp``` is now ```--output-fp```
-	* ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
-	* ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
-	* ```--sc_separated``` is now ```--sc-separated```
-	* ```--int_fields``` is now ```--int-fields```
-	* ```--float_fields``` is now ```--float-fields```
-	* ```--sample_header``` is now ```--sample-header```
-	* ```--observation_header``` is now ```--observation-header```
-	* New option ```--sc-pipe-separated```
+        * ```--input_fp``` is now ```--input-fp```
+        * ```--output_fp``` is now ```--output-fp```
+        * ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
+        * ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
+        * ```--sc_separated``` is now ```--sc-separated```
+        * ```--int_fields``` is now ```--int-fields```
+        * ```--float_fields``` is now ```--float-fields```
+        * ```--sample_header``` is now ```--sample-header```
+        * ```--observation_header``` is now ```--observation-header```
+        * New option ```--sc-pipe-separated```
     * ```biom_validator.py``` is now ```biom validate-table```. Changed option names:
-	* ```-v```/```--verbose``` is now ```--detailed-report```
-	* ```--biom_fp``` is now ```--input-fp```
+        * ```-v```/```--verbose``` is now ```--detailed-report```
+        * ```--biom_fp``` is now ```--input-fp```
     * ```convert_biom.py``` is now ```biom convert```. Changed option names:
-	* ```--input_fp``` is now ```--input-fp```
-	* ```--output_fp``` is now ```--output-fp```
-	* ```--biom_type``` is now ```--matrix-type```
-	* ```--biom_to_classic_table``` is now ```--biom-to-classic-table```
-	* ```--sparse_biom_to_dense_biom``` is now ```--sparse-biom-to-dense-biom```
-	* ```--dense_biom_to_sparse_biom``` is now ```--dense-biom-to-sparse-biom```
-	* ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
-	* ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
-	* ```--header_key``` is now ```--header-key```
-	* ```--output_metadata_id``` is now ```--output-metadata-id```
-	* ```--process_obs_metadata``` is now ```--process-obs-metadata```
-	* ```--biom_table_type``` is now ```--table-type```
+        * ```--input_fp``` is now ```--input-fp```
+        * ```--output_fp``` is now ```--output-fp```
+        * ```--biom_type``` is now ```--matrix-type```
+        * ```--biom_to_classic_table``` is now ```--biom-to-classic-table```
+        * ```--sparse_biom_to_dense_biom``` is now ```--sparse-biom-to-dense-biom```
+        * ```--dense_biom_to_sparse_biom``` is now ```--dense-biom-to-sparse-biom```
+        * ```--sample_mapping_fp``` is now ```--sample-metadata-fp```
+        * ```--observation_mapping_fp``` is now ```--observation-metadata-fp```
+        * ```--header_key``` is now ```--header-key```
+        * ```--output_metadata_id``` is now ```--output-metadata-id```
+        * ```--process_obs_metadata``` is now ```--process-obs-metadata```
+        * ```--biom_table_type``` is now ```--table-type```
     * ```print_biom_python_config.py``` is now ```biom show-install-info```.
     * ```print_biom_table_summary.py``` is now ```biom summarize-table```. Changed option names:
-	* ```--input_fp``` is now ```--input-fp```
-	* ```--output_fp``` is now ```--output-fp```. This is now a required option (output is no longer printed to stdout).
-	* ```--num_observations``` is now ```--qualitative```
-	* ```--suppress_md5``` is now ```--suppress-md5```
+        * ```--input_fp``` is now ```--input-fp```
+        * ```--output_fp``` is now ```--output-fp```. This is now a required option (output is no longer printed to stdout).
+        * ```--num_observations``` is now ```--qualitative```
+        * ```--suppress_md5``` is now ```--suppress-md5```
     * ```subset_biom.py``` is now ```biom subset-table```. Changed option names:
-	* ```--biom_fp``` is now ```--input-fp```
-	* ```--output_fp``` is now ```--output-fp```
-	* ```--ids_fp``` is now ```--ids```
+        * ```--biom_fp``` is now ```--input-fp```
+        * ```--output_fp``` is now ```--output-fp```
+        * ```--ids_fp``` is now ```--ids```
 * ```biom.parse.parse_mapping``` has been replaced by ```biom.parse.MetadataMap```. ```biom.parse.MetadataMap.from_file``` can be directly substituted in place of ```biom.parse.parse_mapping```.
 
 Bug Fixes:

--- a/biom/table.py
+++ b/biom/table.py
@@ -969,7 +969,8 @@ class Table(object):
         ids = set(self.ids(axis=axis)) & set(metadata.index)
         if len(ids) == 0:
             raise TableException("No common ids between table and dataframe.")
-        filter_f = lambda v, i, m: i in ids
+        def filter_f(v, i, m):
+            return i in ids
         t = self.filter(filter_f, axis=axis, inplace=False)
         t.remove_empty()
         md = metadata.loc[t.ids(axis=axis)]

--- a/biom/table.py
+++ b/biom/table.py
@@ -969,8 +969,9 @@ class Table(object):
         ids = set(self.ids(axis=axis)) & set(metadata.index)
         if len(ids) == 0:
             raise TableException("No common ids between table and dataframe.")
-        def filter_f(v, i, m):
-            return i in ids
+
+        def filter_f(v, i, m): return i in ids
+
         t = self.filter(filter_f, axis=axis, inplace=False)
         t.remove_empty()
         md = metadata.loc[t.ids(axis=axis)]
@@ -1002,7 +1003,6 @@ class Table(object):
         order = [n.name for n in _tree.tips()]
         _table = _table.sort_order(order, axis=axis)
         return _table, _tree
-
 
     def reduce(self, f, axis):
         """Reduce over axis using function `f`

--- a/biom/table.py
+++ b/biom/table.py
@@ -965,6 +965,35 @@ class Table(object):
             A filtered biom table.
         pd.DataFrame
             A filtered metadata table.
+
+        Examples
+        --------
+        >>> from biom import Table
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> table = Table(np.array([[0, 0, 1, 1],
+        ...                         [2, 2, 4, 4],
+        ...                         [5, 5, 3, 3],
+        ...                         [0, 0, 0, 1]]),
+        ...               ['o1', 'o2', 'o3', 'o4'],
+        ...               ['s1', 's2', 's3', 's4'])
+        >>> metadata = pd.DataFrame([['a', 'control'],
+        ...                          ['c', 'diseased'],
+        ...                          ['b', 'control']],
+        ...                         index=['s1', 's3', 's2'],
+        ...                         columns=['Barcode', 'Treatment'])
+        >>> res_table, res_metadata = table.align_to_dataframe(metadata)
+        >>> print(res_table)
+        # Constructed from biom file
+        #OTU ID	s1	s2	s3
+        o1	0.0	0.0	1.0
+        o2	2.0	2.0	4.0
+        o3	5.0	5.0	3.0
+        >>> print(res_metadata)
+           Barcode Treatment
+        s1       a   control
+        s2       b   control
+        s3       c  diseased
         """
         ids = set(self.ids(axis=axis)) & set(metadata.index)
         if len(ids) == 0:
@@ -992,6 +1021,32 @@ class Table(object):
             A filtered biom table.
         skbio.TreeNode
             A filtered skbio TreeNode object.
+
+        Examples
+        --------
+        >>> from biom import Table
+        >>> import numpy as np
+        >>> from skbio import TreeNode
+        >>> table = Table(np.array([[0, 0, 1, 1],
+        ...                         [2, 2, 4, 4],
+        ...                         [5, 5, 3, 3],
+        ...                         [0, 0, 0, 1]]),
+        ...               ['o1', 'o2', 'o3', 'o4'],
+        ...               ['s1', 's2', 's3', 's4'])
+        >>> tree = TreeNode.read([u"((o1,o2)f,o3)r;"])
+        >>> res_table, res_tree = table.align_tree(tree)
+        >>> print(res_table)
+        # Constructed from biom file
+        #OTU ID	s1	s2	s3	s4
+        o1	0.0	0.0	1.0	1.0
+        o2	2.0	2.0	4.0	4.0
+        o3	5.0	5.0	3.0	3.0
+        >>> print(res_tree.ascii_art())
+                            /-o1
+                  /f-------|
+        -r-------|          \-o2
+                 |
+                  \-o3
         """
         tips = {x.name for x in tree.tips()}
         common_tips = tips & set(self.ids(axis=axis))

--- a/biom/table.py
+++ b/biom/table.py
@@ -999,6 +999,7 @@ class Table(object):
         common_tips = tips & set(self.ids(axis=axis))
         _tree = tree.shear(names=common_tips)
         _table = self.filter(common_tips, axis=axis, inplace=False)
+        _table.remove_empty()
         _tree.prune()
         order = [n.name for n in _tree.tips()]
         _table = _table.sort_order(order, axis=axis)

--- a/biom/table.py
+++ b/biom/table.py
@@ -948,8 +948,8 @@ class Table(object):
         self._data = self._data.tocsc()
         return self._data.getcol(col_idx)
 
-    def align_metadata(self, metadata, axis='sample'):
-        """ Aligns metadata against biom table, only keeping common ids.
+    def align_to_dataframe(self, metadata, axis='sample'):
+        """ Aligns dataframe against biom table, only keeping common ids.
 
         Parameters
         ----------
@@ -966,10 +966,10 @@ class Table(object):
         pd.DataFrame
             A filtered metadata table.
         """
-        ids = set(self.ids(axis)) & set(metadata.index)
+        ids = set(self.ids(axis=axis)) & set(metadata.index)
         filter_f = lambda v, i, m: i in ids
-        t = self.table.filter(filter_f, axis=axis, inplace=False)
-        md = metadata.loc[self.ids()]
+        t = self.filter(filter_f, axis=axis, inplace=False)
+        md = metadata.loc[t.ids(axis=axis)]
         return t, md
 
     def align_tree(self, tree, axis='sample'):

--- a/biom/table.py
+++ b/biom/table.py
@@ -1005,7 +1005,7 @@ class Table(object):
         return t, md
 
     def align_tree(self, tree, axis='observation'):
-        """ Aligns biom table against tree, only keeping common ids.
+        r""" Aligns biom table against tree, only keeping common ids.
 
         Parameters
         ----------

--- a/biom/table.py
+++ b/biom/table.py
@@ -970,9 +970,7 @@ class Table(object):
         if len(ids) == 0:
             raise TableException("No common ids between table and dataframe.")
 
-        def filter_f(v, i, m): return i in ids
-
-        t = self.filter(filter_f, axis=axis, inplace=False)
+        t = self.filter(ids, axis=axis, inplace=False)
         t.remove_empty()
         md = metadata.loc[t.ids(axis=axis)]
         return t, md

--- a/biom/table.py
+++ b/biom/table.py
@@ -995,6 +995,8 @@ class Table(object):
         """
         tips = {x.name for x in tree.tips()}
         common_tips = tips & set(self.ids(axis=axis))
+        if len(common_tips) == 0:
+            raise TableException("No common ids between table and tree.")
         _tree = tree.shear(names=common_tips)
         _table = self.filter(common_tips, axis=axis, inplace=False)
         _table.remove_empty()

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1853,22 +1853,22 @@ class TableTests(TestCase):
                                 [2, 2, 4, 4],
                                 [5, 5, 3, 3],
                                 [0, 0, 0, 1]]),
-                      ['s1', 's2', 's3', 's4'],
-                      ['o1', 'o2', 'o3', 'o4'])
-        metadata = pd.DataFrame([['a', 'control'],
-                                 ['c', 'diseased'],
-                                 ['b', 'control']],
-                                index=['s1', 's3', 's2'],
+                      ['o1', 'o2', 'o3', 'o4'],
+                      ['s1', 's2', 's3', 's4'])
+        metadata = pd.DataFrame([['a', 'Firmicutes'],
+                                 ['c', 'Proteobacteria'],
+                                 ['b', 'Firmicutes']],
+                                index=['o1', 'o3', 'o2'],
                                 columns=['Barcode', 'Treatment'])
         exp_table = Table(np.array([[0, 0, 1, 1],
                                     [2, 2, 4, 4],
                                     [5, 5, 3, 3]]),
-                          ['s1', 's2', 's3'],
-                          ['o1', 'o2', 'o3', 'o4'])
-        exp_metadata = pd.DataFrame([['a', 'control'],
-                                     ['b', 'control'],
-                                     ['c', 'diseased']],
-                                    index=['s1', 's2', 's3'],
+                          ['o1', 'o2', 'o3'],
+                          ['s1', 's2', 's3', 's4'])
+        exp_metadata = pd.DataFrame([['a', 'Firmicutes'],
+                                     ['b', 'Firmicutes'],
+                                     ['c', 'Proteobacteria']],
+                                    index=['o1', 'o2', 'o3'],
                                     columns=['Barcode', 'Treatment'])
         res_table, res_metadata = table.align_to_dataframe(
             metadata, axis='observation')
@@ -1987,7 +1987,7 @@ class TableTests(TestCase):
         res_table, res_tree = table.align_tree(tree)
         self.assertEqual(res_table.descriptive_equality(exp_table),
                          'Tables appear equal')
-        self.assertEqual(str(exp_tree), str(res_tree))
+        self.assertEqual(exp_tree.compare_rfd(res_tree), 0)
 
     @pytest.mark.skipif(not HAVE_SKBIO, reason="skbio not installed")
     def test_align_tree_sample(self):
@@ -1996,20 +1996,20 @@ class TableTests(TestCase):
                                 [2, 3, 4],
                                 [5, 5, 3],
                                 [0, 0, 1]]),
-                      ['s1', 's2', 's3', 's4'],
-                      ['a', 'b', 'd'])
-        tree = skbio.TreeNode.read([u"(((a,b)f, c),d)r;"])
+                      ['o1', 'o2', 'o3', 'o4'],
+                      ['s1', 's2', 's4'])
+        tree = skbio.TreeNode.read([u"(((s1,s2)F, s3),s4)R;"])
         exp_table = Table(np.array([[1, 0, 0],
                                     [4, 2, 3],
                                     [3, 5, 5],
                                     [1, 0, 0]]),
-                          ['s1', 's2', 's3', 's4'],
-                          ['d', 'a', 'b'])
-        exp_tree = skbio.TreeNode.read([u"(d,(a,b)f)r;"])
+                          ['o1', 'o2', 'o3', 'o4'],
+                          ['s4', 's1', 's2'])
+        exp_tree = skbio.TreeNode.read([u"(s4,(s1,s2)F)R;"])
         res_table, res_tree = table.align_tree(tree, axis='sample')
         self.assertEqual(res_table.descriptive_equality(exp_table),
                          'Tables appear equal')
-        self.assertEqual(str(exp_tree), str(res_tree))
+        self.assertEqual(exp_tree.compare_rfd(res_tree), 0)
 
     def test_get_value_by_ids(self):
         """Return the value located in the matrix by the ids"""

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -47,7 +47,7 @@ except ImportError:
 
 try:
     import skbio
-    HAVE_SKBIO = False
+    HAVE_SKBIO = True
 except ImportError:
     HAVE_SKBIO = False
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1978,8 +1978,8 @@ class TableTests(TestCase):
                       ['s1', 's2', 's3', 's4'])
         tree = skbio.TreeNode.read([u"(((a,b)f, c),d)r;"])
         exp_table = Table(np.array([[1, 0, 0],
-                                     [4, 2, 3],
-                                     [3, 5, 5],
+                                    [4, 2, 3],
+                                    [3, 5, 5],
                                     [1, 0, 0]]).T,
                           ['d', 'a', 'b'],
                           ['s1', 's2', 's3', 's4'])
@@ -2000,8 +2000,8 @@ class TableTests(TestCase):
                       ['a', 'b', 'd'])
         tree = skbio.TreeNode.read([u"(((a,b)f, c),d)r;"])
         exp_table = Table(np.array([[1, 0, 0],
-                                     [4, 2, 3],
-                                     [3, 5, 5],
+                                    [4, 2, 3],
+                                    [3, 5, 5],
                                     [1, 0, 0]]),
                           ['s1', 's2', 's3', 's4'],
                           ['d', 'a', 'b'])

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -1935,7 +1935,7 @@ class TableTests(TestCase):
                                 [2, 2, 4, 0],
                                 [5, 5, 3, 0],
                                 [0, 0, 0, 1]]),
-                      ['s1', 's2', 's3', 's4']
+                      ['s1', 's2', 's3', 's4'],
                       ['o1', 'o2', 'o3', 'o4'])
         metadata = pd.DataFrame([['a', 'control'],
                                  ['c', 'diseased'],


### PR DESCRIPTION
This pull request adds alignment functionality, to allow the biom table to be aligned against metadata (represented as `pd.DataFrame`) and trees (represented as `skbio.TreeNode`).

I have made this a little more general, allowing these alignment methods to be performed on both axes (sample and observations). 

Once we have agreed on the basic user interface, I will push in the remaining unittests.

Outstanding questions
1. Should we enable an inplace option?  Maybe useful for massive datasets.
2. Should we enable a `how` or `join` flag, specifying if this is going to be an inner, outer, left or right join?  Right now, I'm only implementing an inner flag since those are my only use cases.  But if there is a compelling use case, I am open for discussion.