### PR TITLE
Improve Table.collapse by roughly 10x

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -462,7 +462,7 @@ class Table(object):
                  observation_metadata=None, sample_metadata=None,
                  table_id=None, type=None, create_date=None, generated_by=None,
                  observation_group_metadata=None, sample_group_metadata=None,
-                 **kwargs):
+                 validate=True, **kwargs):
 
         self.type = type
         self.table_id = table_id
@@ -507,7 +507,8 @@ class Table(object):
         self._sample_group_metadata = sample_group_metadata
         self._observation_group_metadata = observation_group_metadata
 
-        errcheck(self)
+        if validate:
+            errcheck(self)
 
         # These will be set by _index_ids()
         self._sample_index = None
@@ -2452,7 +2453,7 @@ class Table(object):
                 samp_md = md[:] if md is not None else None
 
             yield part, Table(data, obs_ids, samp_ids, obs_md, samp_md,
-                              self.table_id, type=self.type)
+                              self.table_id, type=self.type, validate=False)
 
     def collapse(self, f, collapse_f=None, norm=True, min_group_size=1,
                  include_collapsed_metadata=True, one_to_many=False,

--- a/biom/table.py
+++ b/biom/table.py
@@ -462,7 +462,8 @@ class Table(object):
                  observation_metadata=None, sample_metadata=None,
                  table_id=None, type=None, create_date=None, generated_by=None,
                  observation_group_metadata=None, sample_group_metadata=None,
-                 validate=True, **kwargs):
+                 validate=True, observation_index=None, sample_index=None,
+                 **kwargs):
 
         self.type = type
         self.table_id = table_id
@@ -515,15 +516,22 @@ class Table(object):
         self._obs_index = None
 
         self._cast_metadata()
-        self._index_ids()
+        self._index_ids(observation_index, sample_index)
 
-    def _index_ids(self):
+    def _index_ids(self, observation_index, sample_index):
         """Sets lookups {id:index in _data}.
 
         Should only be called in constructor as this modifies state.
         """
-        self._sample_index = index_list(self._sample_ids)
-        self._obs_index = index_list(self._observation_ids)
+        if sample_index is None:
+            self._sample_index = index_list(self._sample_ids)
+        else:
+            self._sample_index = sample_index
+
+        if observation_index is None:
+            self._obs_index = index_list(self._observation_ids)
+        else:
+            self._obs_index = observation_index
 
     def _index(self, axis='sample'):
         """Return the index lookups of the given axis
@@ -1422,7 +1430,7 @@ class Table(object):
         else:
             result._observation_ids = updated_ids
 
-        result._index_ids()
+        result._index_ids(None, None)
 
         # check for errors (specifically, we want to esnsure that duplicate
         # ids haven't been introduced)
@@ -2359,11 +2367,12 @@ class Table(object):
         if axis == 1:
             table._sample_ids = ids
             table._sample_metadata = metadata
+            table._index_ids(self._obs_index.copy(), None)
         elif axis == 0:
             table._observation_ids = ids
             table._observation_metadata = metadata
+            table._index_ids(None, self._sample_index.copy())
 
-        table._index_ids()
         errcheck(table)
 
         return table
@@ -2444,6 +2453,7 @@ class Table(object):
                 samp_md = metadata
                 obs_ids = self.ids(axis='observation')[:]
                 obs_md = md[:] if md is not None else None
+                indices = {'observation_index': self._obs_index.copy()}
 
             elif axis == 'observation':
                 data = self._conv_to_self_type(values, transpose=False)
@@ -2451,9 +2461,11 @@ class Table(object):
                 obs_md = metadata
                 samp_ids = self.ids()[:]
                 samp_md = md[:] if md is not None else None
+                indices = {'sample_index': self._sample_index.copy()}
 
             yield part, Table(data, obs_ids, samp_ids, obs_md, samp_md,
-                              self.table_id, type=self.type, validate=False)
+                              self.table_id, type=self.type, validate=False,
+                              **indices)
 
     def collapse(self, f, collapse_f=None, norm=True, min_group_size=1,
                  include_collapsed_metadata=True, one_to_many=False,

--- a/biom/util.py
+++ b/biom/util.py
@@ -204,7 +204,7 @@ def prefer_self(x, y):
 
 def index_list(item):
     """Takes a list and returns {l[idx]:idx}"""
-    return dict([(id_, idx) for idx, id_ in enumerate(item)])
+    return {id_: idx for idx, id_ in enumerate(item)}
 
 
 def load_biom_config():


### PR DESCRIPTION
For collapses requiring high volumes of partitions, these changes empirically offered about a 10x reduction in runtime. In particular, this greatly improves performance for `redbiom.fetch` when merging samples.