### PR TITLE
Clarification about ID type in the docs for Table.update_ids

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         conda create --yes -n env_name python=3.6
         conda activate env_name
-        conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio anndata
+        conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
         pip install sphinx==1.2.2 'docutils<0.14'
         pip install -e . --no-deps
     - name: Build docs
@@ -62,8 +62,7 @@ jobs:
       run: |
         conda create --yes -n env_name python=${{ matrix.python-version }}
         conda activate env_name
-        conda install -y pip click numpy 'scipy>=1.3.1' 'pandas>=0.20.0' 'h5py>=2.2.0' cython 'pytest>=6.2.4' flake8
-        pip install anndata
+        conda install -y pip click numpy 'scipy>=1.3.1' 'pandas>=0.20.0' 'h5py>=2.2.0' cython 'pytest>=6.2.4' flake8 anndata
 
     - name: Tests
       shell: bash -l {0}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -34,9 +34,9 @@ jobs:
       run: |
         conda create --yes -n env_name python=3.6
         conda activate env_name
-        conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
+        conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio anndata
         pip install sphinx==1.2.2 'docutils<0.14'
-        pip install -e .[hdf5,anndata] --no-deps
+        pip install -e . --no-deps
     - name: Build docs
       shell: bash -l {0}
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -36,7 +36,7 @@ jobs:
         conda activate env_name
         conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
         pip install sphinx==1.2.2 'docutils<0.14'
-        pip install -e . --no-deps
+        pip install -e .[hdf5,anndata] --no-deps
     - name: Build docs
       shell: bash -l {0}
       run: |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-README
-======
+The Biological Observation Matrix (BIOM) format
+===============================================
 
 [![Join the chat at https://gitter.im/biocore/biom-format](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/biocore/biom-format?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build Status](https://travis-ci.org/biocore/biom-format.png?branch=master)](https://travis-ci.org/biocore/biom-format) [![Coverage Status](https://coveralls.io/repos/biocore/biom-format/badge.png)](https://coveralls.io/r/biocore/biom-format)
+[![biom-format CI](https://github.com/biocore/biom-format/actions/workflows/python-package-conda.yml/badge.svg)](https://github.com/biocore/biom-format/actions/workflows/python-package-conda.yml)
 
 The BIOM file format (canonically pronounced *biome*) is designed to be a general-use format for representing counts of observations (e.g., OTUs, KO categories, lipid types) in one or more biological samples (e.g., microbiome samples, genomes, metagenomes).
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Further details can be found at http://biom-format.org.
 Getting help
 ------------
 
-To get help with biom, you should use the [biom](http://stackoverflow.com/questions/tagged/biom) tag on StackOverflow (SO), or post the the [QIIME 2 Forum](http://forum.qiime2.org). Before posting a question, check out SO's guide on how to [ask a question](http://stackoverflow.com/questions/how-to-ask). The biom-format developers regularly monitor the `biom` SO tag.
+To get help with biom, you should use the [biom](http://stackoverflow.com/questions/tagged/biom) tag on StackOverflow (SO), or post to the [QIIME 2 Forum](http://forum.qiime2.org). Before posting a question, check out SO's guide on how to [ask a question](http://stackoverflow.com/questions/how-to-ask). The biom-format developers regularly monitor the `biom` SO tag.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Further details can be found at http://biom-format.org.
 Getting help
 ------------
 
-To get help with biom, you should use the [biom](http://stackoverflow.com/questions/tagged/biom) tag on StackOverflow (SO), or post the the [QIIME Forum](http://forum.qiime.org). Before posting a question, check out SO's guide on how to [ask a question](http://stackoverflow.com/questions/how-to-ask). The biom-format developers regularly monitor the `biom` SO tag.
+To get help with biom, you should use the [biom](http://stackoverflow.com/questions/tagged/biom) tag on StackOverflow (SO), or post the the [QIIME 2 Forum](http://forum.qiime2.org). Before posting a question, check out SO's guide on how to [ask a question](http://stackoverflow.com/questions/how-to-ask). The biom-format developers regularly monitor the `biom` SO tag.

--- a/biom/table.py
+++ b/biom/table.py
@@ -19,7 +19,7 @@ Classes
 
 Examples
 --------
-First, lets create a toy table to play around with. For this example, we're
+First, let's create a toy table to play around with. For this example, we're
 going to construct a 10x4 `Table`, or one that has 10 observations and 4
 samples. Each observation and sample will be given an arbitrary but unique
 name. We'll also add on some metadata.
@@ -1349,12 +1349,13 @@ class Table:
             raise UnknownAxisError(axis)
 
     def update_ids(self, id_map, axis='sample', strict=True, inplace=True):
-        """Update the ids along the given axis
+        """Update the ids along the given axis.
 
         Parameters
         ----------
         id_map : dict
-            Mapping of old to new ids
+            Mapping of old to new ids. All keys and values in this dict should
+            be strings.
         axis : {'sample', 'observation'}, optional
             Axis to search for `id`. Defaults to 'sample'
         strict : bool, optional


### PR DESCRIPTION
I'm not sure if non-string IDs were ever officially supported for BIOM tables, but some of the Empress test code ([these lines, in particular](https://github.com/biocore/empress/blob/bf6f755c5187e543ff13c2c624b153fb97918b23/tests/python/test_tools.py#L143-L145)) involved setting IDs to integers. It looks like [this commit](https://github.com/biocore/biom-format/commit/3876827597658d4a05192958c715ef4738c30ef5) broke this behavior, and by extension this particular Empress test -- it triggered the following error:

```
ERROR: test_match_inputs_no_tips_in_table (python.test_tools.TestTools)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/empress/empress/tests/python/test_tools.py", line 143, in test_match_inputs_no_tips_in_table
    bad_table.update_ids({i: idx for idx, i in
  File "/usr/share/miniconda/envs/empress/lib/python3.9/site-packages/biom/table.py", line 1405, in update_ids
    str_dtype = 'U%d' % max([len(v) for v in id_map.values()])
  File "/usr/share/miniconda/envs/empress/lib/python3.9/site-packages/biom/table.py", line 1405, in <listcomp>
    str_dtype = 'U%d' % max([len(v) for v in id_map.values()])
TypeError: object of type 'int' has no len()
```

This PR documents explicitly that both keys and values for the `id_map` parameter of `Table.update_ids()` should be strings. I haven't added any validation code that checks this (I'm not sure if the added runtime incurred by such a check would be desirable, and this seems like it'd be a pretty weird thing for users to try to do normally...?), but hopefully this clarifies things for future devs who encounter this problem on updating to newer versions of `biom-format`.

This PR also includes two small grammar fixes.

Thanks!