### PR TITLE
PERF: use sparse matrix for table.collapse(..., one_to_many=True)

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,7 +13,7 @@ jobs:
     - name: flake8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.10'
     - name: install dependencies
       run: python -m pip install --upgrade pip
     - name: lint
@@ -28,11 +28,11 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: '3.6'
+        python-version: '3.10'
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda create --yes -n env_name python=3.6
+        conda create --yes -n env_name python=3.10
         conda activate env_name
         conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
         pip install sphinx==1.2.2 'docutils<0.14'
@@ -46,7 +46,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.6', '3.10']
+        python-version: ['3.7', '3.10']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -35,7 +35,7 @@ jobs:
         conda create --yes -n env_name python=3.7
         conda activate env_name
         conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
-        pip install sphinx==1.2.2 'docutils<0.14'
+        pip install "sphinx<1.3" 'docutils<0.14'
         pip install -e . --no-deps
     - name: Build docs
       shell: bash -l {0}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -28,11 +28,11 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: '3.10'
+        python-version: '3.7'
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda create --yes -n env_name python=3.10
+        conda create --yes -n env_name python=3.7
         conda activate env_name
         conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
         pip install sphinx==1.2.2 'docutils<0.14'

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -35,7 +35,7 @@ jobs:
         conda create --yes -n env_name python=3.7
         conda activate env_name
         conda install --name env_name pip click numpy 'scipy>=1.3.1' pep8 flake8 coverage 'pandas>=0.20.0' nose 'h5py>=2.2.0' cython scikit-bio
-        pip install "sphinx<1.3" 'docutils<0.14'
+        pip install "sphinx<1.3" 'docutils<0.14' "jinja2<3.1.0"
         pip install -e . --no-deps
     - name: Build docs
       shell: bash -l {0}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 BIOM-Format ChangeLog
 =====================
 
+biom 2.1.11-dev
+---------------
+
+New features
+
+* `table.collapse(..., one_to_many=True)` now uses a sparse matrix on construction, substantially reducing memory overhead [PR #884](https://github.com/biocore/biom-format/pull/884).
+
 biom 2.1.11
 -----------
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,11 @@ BIOM-Format ChangeLog
 biom 2.1.11-dev
 ---------------
 
-New features
+Important:
+
+* Python 3.6 testing support has been removed.
+
+New features:
 
 * `table.collapse(..., one_to_many=True)` now uses a sparse matrix on construction, substantially reducing memory overhead [PR #884](https://github.com/biocore/biom-format/pull/884).
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -2712,8 +2712,8 @@ class Table:
                             new_data[axis_update(vidx, column)] += v
                     else:
                         dv = md_count[id_]
-                        for vidx, v in enumerate(vals):
-                            new_data[axis_update(vidx, column)] += (v / dv)
+                        for vidx, v in enumerate(vals / dv):
+                            new_data[axis_update(vidx, column)] += v
 
             if include_collapsed_metadata:
                 # reassociate pathway information

--- a/biom/table.py
+++ b/biom/table.py
@@ -2670,7 +2670,7 @@ class Table:
 
             # We need to store floats, not ints, as things won't always divide
             # evenly.
-            dtype = np.float if one_to_many_mode == 'divide' else self.dtype
+            dtype = np.float64 if one_to_many_mode == 'divide' else self.dtype
 
             nds = new_data_shape(self.ids(self._invert_axis(axis)),
                                  new_md)

--- a/biom/table.py
+++ b/biom/table.py
@@ -2698,6 +2698,14 @@ class Table:
                     except StopIteration:
                         break
 
+                    # TODO: refactor Table.collapse(..., one_to_many=True) so
+                    # writes into new_data are performed without regard to
+                    # the requested axis, and perform a single transpose at the
+                    # end. Right now we incur many calls to `axis_update` which
+                    # could be avoided. However, this refactor is likely
+                    # complex to do correctly, so punting for now as we don't
+                    # yet have data showing this is a real world performance
+                    # concern.
                     column = idx_lookup[part]
                     if one_to_many_mode == 'add':
                         for vidx, v in enumerate(vals):

--- a/biom/table.py
+++ b/biom/table.py
@@ -2607,7 +2607,6 @@ class Table:
 
         # transpose is only necessary in the one-to-one case
         # new_data_shape is only necessary in the one-to-many case
-        # axis_slice is only necessary in the one-to-many case
         def axis_ids_md(t):
             return (t.ids(axis=axis), t.metadata(axis=axis))
 
@@ -2617,17 +2616,11 @@ class Table:
             def new_data_shape(ids, collapsed):
                 return (len(ids), len(collapsed))
 
-            def axis_slice(lookup, key):
-                return (slice(None), lookup[key])
-
         elif axis == 'observation':
             transpose = False
 
             def new_data_shape(ids, collapsed):
                 return (len(collapsed), len(ids))
-
-            def axis_slice(lookup, key):
-                return (lookup[key], slice(None))
 
         else:
             raise UnknownAxisError(axis)

--- a/biom/table.py
+++ b/biom/table.py
@@ -2607,6 +2607,7 @@ class Table:
 
         # transpose is only necessary in the one-to-one case
         # new_data_shape is only necessary in the one-to-many case
+        # axis_update is only necessary in the one-to-many case
         def axis_ids_md(t):
             return (t.ids(axis=axis), t.metadata(axis=axis))
 
@@ -2616,11 +2617,17 @@ class Table:
             def new_data_shape(ids, collapsed):
                 return (len(ids), len(collapsed))
 
+            def axis_update(offaxis, onaxis):
+                return (offaxis, onaxis)
+
         elif axis == 'observation':
             transpose = False
 
             def new_data_shape(ids, collapsed):
                 return (len(collapsed), len(ids))
+
+            def axis_update(offaxis, onaxis):
+                return (onaxis, offaxis)
 
         else:
             raise UnknownAxisError(axis)
@@ -2694,11 +2701,11 @@ class Table:
                     column = idx_lookup[part]
                     if one_to_many_mode == 'add':
                         for vidx, v in enumerate(vals):
-                            new_data[vidx, column] += v
+                            new_data[axis_update(vidx, column)] += v
                     else:
-                        divisor = md_count[id_]
+                        dv = md_count[id_]
                         for vidx, v in enumerate(vals):
-                            new_data[vidx, column] += (v / divisor)
+                            new_data[axis_update(vidx, column)] += (v / dv)
 
             if include_collapsed_metadata:
                 # reassociate pathway information


### PR DESCRIPTION
Avoid dense representation on one_to_many. This code path was implicated in `woltka collapse`. 

Note this is a WIP, I am asserting the memory reduction in `woltka collapse` right now. However, the high memory requirement is nearly certainly due to the dense memory representation previously used. 

cc @antgonza @qiyunzhu