### PR TITLE
chore: remove cython from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,6 @@ install_requires = [
     "numpy >= 1.9.2",
     "scipy >= 1.3.1",
     'pandas >= 0.20.0',
-    "cython >= 0.29",
     "h5py",
 ]
 


### PR DESCRIPTION
I didn't see instructions regarding whether the PR should be merged into master or develop.

Fix #898 

Remove Cython from the package requirements since it's only needed at installation time and already listed in `pyproject.toml` build requirements.

I didn't make any other changes here but I did notice that the whole package installation/building configuration uses outdated mechanisms. You may consider making further changes:

* Setuptools now [fully supports pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). This would let you get rid of `setup.cfg` and `pytest.ini` as well.
* Supporting `python setup.py test` is not typically done anymore.
* You can pre-compile your `.pyx` modules into `.c` ones and make those part of your source distribution instead. In that case, cython wouldn't even be needed at installation time but only when making your `sdist`.