### PR TITLE
locale.format --> locale.format_string

### DIFF
--- a/biom/cli/table_summarizer.py
+++ b/biom/cli/table_summarizer.py
@@ -80,20 +80,20 @@ def _summarize_table(table, qualitative=False, observations=False):
 
     if observations:
         # as this is a transpose of the original table...
-        lines.append('Num samples: ' + locale.format('%d', num_observations,
-                                                     grouping=True))
-        lines.append('Num observations: ' + locale.format('%d', num_samples,
-                                                          grouping=True))
+        lines.append('Num samples: ' + locale.format_string('%d',
+                     num_observations, grouping=True))
+        lines.append('Num observations: ' + locale.format_string('%d',
+                     num_samples, grouping=True))
     else:
-        lines.append('Num samples: ' + locale.format('%d', num_samples,
-                                                     grouping=True))
-        lines.append('Num observations: ' + locale.format('%d',
+        lines.append('Num samples: ' + locale.format_string('%d',
+                     num_samples, grouping=True))
+        lines.append('Num observations: ' + locale.format_string('%d',
                      num_observations, grouping=True))
 
     if not qualitative:
         total_count = sum(counts_per_sample_values)
-        lines.append('Total count: ' + locale.format('%d', total_count,
-                                                     grouping=True))
+        lines.append('Total count: ' + locale.format_string('%d',
+                     total_count, grouping=True))
         lines.append('Table density (fraction of non-zero values): %1.3f' %
                      table.get_table_density())
 
@@ -107,13 +107,15 @@ def _summarize_table(table, qualitative=False, observations=False):
     else:
         lines.append('Counts/sample summary:')
 
-    lines.append(' Min: ' + locale.format('%1.3f', min_counts, grouping=True))
-    lines.append(' Max: ' + locale.format('%1.3f', max_counts, grouping=True))
-    lines.append(' Median: ' + locale.format('%1.3f', median_counts,
-                                             grouping=True))
-    lines.append(' Mean: ' + locale.format('%1.3f', mean_counts,
-                                           grouping=True))
-    lines.append(' Std. dev.: ' + locale.format('%1.3f',
+    lines.append(' Min: ' + locale.format_string('%1.3f',
+                 min_counts, grouping=True))
+    lines.append(' Max: ' + locale.format_string('%1.3f',
+                 max_counts, grouping=True))
+    lines.append(' Median: ' + locale.format_string('%1.3f',
+                 median_counts, grouping=True))
+    lines.append(' Mean: ' + locale.format_string('%1.3f',
+                 mean_counts, grouping=True))
+    lines.append(' Std. dev.: ' + locale.format_string('%1.3f',
                  std(counts_per_sample_values), grouping=True))
 
     if observations:
@@ -140,6 +142,7 @@ def _summarize_table(table, qualitative=False, observations=False):
         lines.append('Counts/sample detail:')
 
     for k, v in sorted(counts_per_samp.items(), key=itemgetter(1)):
-        lines.append('%s: ' % k + locale.format('%1.3f', v, grouping=True))
+        lines.append('%s: ' % k + locale.format_string('%1.3f',
+                     v, grouping=True))
 
     return "\n".join(lines)


### PR DESCRIPTION
``locale.format`` was deprecated in Python 3.7, see https://docs.python.org/3/library/locale.html#locale.format
 
Closes #908