### PR TITLE
Explicitly allow setting a random seed for subsample

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,9 @@ BIOM-Format ChangeLog
 biom 2.1.14-dev
 ---------------
 
-Changes go here
+New features:
+
+* You can now set a random seed at the call to `Table.subsample`, see issue [#914](https://github.com/biocore/biom-format/issues/914).
 
 biom 2.1.14
 -----------

--- a/biom/_subsample.pyx
+++ b/biom/_subsample.pyx
@@ -11,7 +11,7 @@ import numpy as np
 cimport numpy as cnp
 
 
-def _subsample(arr, n, with_replacement):
+def _subsample(arr, n, with_replacement, rng):
     """Subsample non-zero values of a sparse array
 
     Parameters
@@ -20,7 +20,12 @@ def _subsample(arr, n, with_replacement):
         A 1xM sparse vector
     n : int
         Number of items to subsample from `arr`
-    
+    with_replacement : bool
+        Whether to permute or use multinomial sampling
+    rng : Generator instance
+        A random generator. This will likely be an instance returned 
+        by np.random.default_rng
+
     Returns
     -------
     ndarray
@@ -49,7 +54,7 @@ def _subsample(arr, n, with_replacement):
         
         if with_replacement:
             pvals = data[start:end] / counts_sum
-            data[start:end] = np.random.multinomial(n, pvals)
+            data[start:end] = rng.multinomial(n, pvals)
         else:
             if counts_sum < n:
                 data[start:end] = 0
@@ -57,7 +62,7 @@ def _subsample(arr, n, with_replacement):
 
             r = np.arange(length, dtype=np.int32)
             unpacked = np.repeat(r, data_i[start:end])
-            permuted = np.random.permutation(unpacked)[:n]
+            permuted = rng.permutation(unpacked)[:n]
 
             result = np.zeros(length, dtype=np.float64)
             for idx in range(permuted.shape[0]):

--- a/biom/table.py
+++ b/biom/table.py
@@ -2871,7 +2871,8 @@ class Table:
 
         return max_val
 
-    def subsample(self, n, axis='sample', by_id=False, with_replacement=False):
+    def subsample(self, n, axis='sample', by_id=False, with_replacement=False,
+                  seed=None):
         """Randomly subsample without replacement.
 
         Parameters
@@ -2889,6 +2890,8 @@ class Table:
             If `False` (default), subsample without replacement. If `True`,
             resample with replacement via the multinomial distribution.
             Should not be `True` if `by_id` is `True`.
+        seed : int, optional
+            If provided, set the numpy random seed with this value
 
         Returns
         -------
@@ -2941,6 +2944,9 @@ class Table:
         [('S1', 'S2'), ('S1', 'S3'), ('S2', 'S3')]
 
         """
+        if seed is not None:
+            np.random.seed(seed)
+
         if n < 0:
             raise ValueError("n cannot be negative.")
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -2944,9 +2944,6 @@ class Table:
         [('S1', 'S2'), ('S1', 'S3'), ('S2', 'S3')]
 
         """
-        if seed is not None:
-            np.random.seed(seed)
-
         if n < 0:
             raise ValueError("n cannot be negative.")
 
@@ -2955,14 +2952,16 @@ class Table:
 
         table = self.copy()
 
+        rng = np.random.default_rng(seed)
+
         if by_id:
             ids = table.ids(axis=axis).copy()
-            np.random.shuffle(ids)
+            rng.shuffle(ids)
             subset = set(ids[:n])
             table.filter(lambda v, i, md: i in subset, axis=axis)
         else:
             data = table._get_sparse_data()
-            _subsample(data, n, with_replacement)
+            _subsample(data, n, with_replacement, rng)
             table._data = data
 
             table.filter(lambda v, i, md: v.sum() > 0, axis=axis)

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -3144,12 +3144,20 @@ class SparseTableTests(TestCase):
         with errstate(empty='raise'), self.assertRaises(TableException):
             self.st_rich.filter(f, 'observation')
 
-    def test_subsample_same_seed(self):
+    def test_subsample_same_seed_without_replacement(self):
         table = Table(np.array([[3, 1, 2], [0, 3, 4]]), ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])
         exp = table.subsample(2, seed=1234)
         for _ in range(100):
             obs = table.subsample(2, seed=1234)
+            self.assertEqual(obs, exp)
+
+    def test_subsample_same_seed_with_replacement(self):
+        table = Table(np.array([[3, 1, 2], [0, 3, 4]]), ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        exp = table.subsample(2, seed=1234, with_replacement=True)
+        for _ in range(100):
+            obs = table.subsample(2, seed=1234, with_replacement=True)
             self.assertEqual(obs, exp)
 
     def test_subsample_by_id(self):

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -16,7 +16,7 @@ import numpy.testing as npt
 import numpy as np
 from scipy.sparse import lil_matrix, csr_matrix, csc_matrix
 import scipy.sparse
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pandas as pd
 import pytest
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -3144,6 +3144,14 @@ class SparseTableTests(TestCase):
         with errstate(empty='raise'), self.assertRaises(TableException):
             self.st_rich.filter(f, 'observation')
 
+    def test_subsample_same_seed(self):
+        table = Table(np.array([[3, 1, 2], [0, 3, 4]]), ['O1', 'O2'],
+                      ['S1', 'S2', 'S3'])
+        exp = table.subsample(2, seed=1234)
+        for _ in range(100):
+            obs = table.subsample(2, seed=1234)
+            self.assertEqual(obs, exp)
+
     def test_subsample_by_id(self):
         table = Table(np.array([[3, 1, 2], [0, 3, 4]]), ['O1', 'O2'],
                       ['S1', 'S2', 'S3'])

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,7 +50,7 @@ Contents
 BIOM version
 ============
 
-The latest official version of the biom-format project is |release| and of the BIOM file format is 2.0. Details on the `file format can be found here <./documentation/biom_format.html>`_.
+The latest official version of the biom-format project is |release| and of the BIOM file format is 2.1. Details on the `file format can be found here <./documentation/biom_format.html>`_.
 
 Installing the ``biom-format`` Python package
 =============================================


### PR DESCRIPTION
Fixes #914. You can now specify the random seed on call to `Table.subsample(...)`.

cc @gibsramen @rob-knight  