### PR TITLE
Issue 892

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,9 +4,15 @@ BIOM-Format ChangeLog
 biom 2.1.14-dev
 ---------------
 
+Bug fixes:
+
+* Do not modify IDs in place in the presence of duplicate relabels, see issue [#892](https://github.com/biocore/biom-format/issues/892)
+
 New features:
 
 * You can now set a random seed at the call to `Table.subsample`, see issue [#914](https://github.com/biocore/biom-format/issues/914).
+
+
 
 biom 2.1.14
 -----------

--- a/biom/table.py
+++ b/biom/table.py
@@ -1414,6 +1414,12 @@ class Table:
 
             updated_ids[idx] = id_map.get(old_id, old_id)
 
+        # see issue #892, this protects against modifying inplace with bad
+        # duplicate identifiers
+        if inplace:
+            if len(updated_ids) != len(set(updated_ids)):
+                raise TableException("Duplicate IDs observed")
+
         # prepare the result object and update the ids along the specified
         # axis
         result = self if inplace else self.copy()
@@ -1424,7 +1430,7 @@ class Table:
 
         result._index_ids(None, None)
 
-        # check for errors (specifically, we want to esnsure that duplicate
+        # check for errors (specifically, we want to ensure that duplicate
         # ids haven't been introduced)
         errcheck(result)
 

--- a/biom/tests/test_table.py
+++ b/biom/tests/test_table.py
@@ -2360,6 +2360,13 @@ class SparseTableTests(TestCase):
                          self.st_rich.data('2', 'observation'))
         self.assertEqual(obs.transpose(), self.st_rich)
 
+    def test_update_ids_inplace_bug_892(self):
+        t = example_table.copy()
+        exp = t.ids().copy()
+        with self.assertRaises(TableException):
+            t.update_ids({i: 'foo' for i in t.ids()}, inplace=True)
+        npt.assert_equal(t.ids(), exp)
+
     def test_update_ids(self):
         """ids are updated as expected"""
         # update observation ids


### PR DESCRIPTION
Fixes #892, and specifically protects the case of duplicate IDs in update when operating inplace