### PR TITLE
Faster merge

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 BIOM-Format ChangeLog
 =====================
 
+biom 2.1.15-dev
+---------------
+
+Performance improvements:
+
+* Revise `Table._fast_merge` to use COO directly. For very large tables, this reduces runtime by ~50x and memory by ~5x. See PR [#913](https://github.com/biocore/biom-format/pull/933).
+
 biom 2.1.15
 -----------
 

--- a/biom/table.py
+++ b/biom/table.py
@@ -178,7 +178,7 @@ from copy import deepcopy
 from datetime import datetime
 from json import dumps as _json_dumps, JSONEncoder
 from functools import reduce, partial
-from operator import itemgetter, or_
+from operator import itemgetter
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
 from numpy import ndarray, asarray, zeros, newaxis
@@ -193,7 +193,6 @@ from biom.util import (get_biom_format_version_string,
                        prefer_self, index_list, H5PY_VLEN_STR,
                        __format_version__)
 from biom.err import errcheck
-import bisect
 from ._filter import _filter
 from ._transform import _transform
 from ._subsample import _subsample
@@ -3673,10 +3672,10 @@ class Table:
             # index positions in the full matrix
             row_map = np.array([feature_map[i]
                                 for i in table.ids(axis='observation')],
-                                dtype=np.int32)
+                               dtype=np.int32)
             col_map = np.array([sample_map[i]
                                 for i in table.ids()],
-                                dtype=np.int32)
+                               dtype=np.int32)
             coo.row = row_map[coo.row]
             coo.col = col_map[coo.col]
 


### PR DESCRIPTION
`Table._fast_merge` was performing poorly on large tables. Here we revise the algorithm used.

List based, on large data, we get:

```bash
        User time (seconds): 2990.23
        Elapsed (wall clock) time (h:mm:ss or m:ss): 51:55.52
        Maximum resident set size (kbytes): 52802340
```