### PR TITLE
WIP Supporting Windows and Python 3.12

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -9,8 +9,8 @@ on:
     branches: [ master ]
 
 env:
-  latest_python: "3.11"
-  supported_pythons: '["3.7", "3.8", "3.9", "3.10", "3.11"]'
+  latest_python: "3.12"
+  supported_pythons: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
   miniforge_version: "22.9.0-2"
   miniforge_variant: "Mambaforge"
 
@@ -34,7 +34,7 @@ jobs:
     needs: conf
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -56,7 +56,7 @@ jobs:
     needs: ["conf", "lint"]
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -81,11 +81,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python_version: ${{ fromJSON(needs.conf.outputs.supported_pythons) }}
         use_conda: [true, false]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -115,7 +115,7 @@ jobs:
     needs: ["conf", "lint", "doc", "test-all"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # setup-buildx-action uses the git context directly
         # but checklist wants the .git directory
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build distribution
         run: |
@@ -15,7 +15,7 @@ jobs:
           pip install numpy cython
           pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist-artifacts
           path: dist/*.tar.gz
@@ -27,13 +27,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        pyver: ["37", "38", "39", "310", "311"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        pyver: ["37", "38", "39", "310", "311", "312"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -47,7 +47,7 @@ jobs:
       - name: Build wheels (py ${{ matrix.pyver }}) Linux
         if: matrix.os == 'ubuntu-latest' 
         env:
-          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_SKIP: "*-musllinux*"
           CIBW_BUILD: "cp${{ matrix.pyver }}-*"
 
@@ -60,10 +60,15 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.pyver }}-*"
 
         uses: pypa/cibuildwheel@v2.12.3
-      
-      
+
+      - name: Build wheels (py ${{ matrix.pyver }}) Windows
+        if: matrix.os == 'windows-latest'
+        env:
+          CIBW_ARCHS_WINDOWS: "amd64 win32 arm64"
+          CIBW_BUILD: "cp${{ matrix.pyver }}-*"
+
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-artifacts
           path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -86,15 +86,20 @@ classes = """
     Topic :: Software Development :: Libraries :: Application Frameworks
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: OS Independent
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
 """
 classifiers = [s.strip() for s in classes.split('\n') if s]
 


### PR DESCRIPTION
This PR adds build support for Windows and Python 3.12. Following a discussion with @wasade and @mataton, we realized that biom-format might have already supported Windows, and it just needs to be officially added. The CI workflow will tell whether it is the case.