### PR TITLE
added numpy-2.0 support

### DIFF
--- a/biom/_filter.pyx
+++ b/biom/_filter.pyx
@@ -13,6 +13,7 @@ from types import FunctionType
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 cdef cnp.ndarray[cnp.uint8_t, ndim=1] \

--- a/biom/_subsample.pyx
+++ b/biom/_subsample.pyx
@@ -8,6 +8,8 @@
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
+
 
 cdef _subsample_with_replacement(cnp.ndarray[cnp.float64_t, ndim=1] data,
                                  cnp.ndarray[cnp.int32_t, ndim=1] indptr,

--- a/biom/_transform.pyx
+++ b/biom/_transform.pyx
@@ -9,6 +9,7 @@
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 def _transform(arr, ids, metadata, function, axis):


### PR DESCRIPTION
See [here](https://github.com/scikit-bio/scikit-bio/issues/1964#issuecomment-2040309909). To test whether this patch will work, we need to wait until [h5py 3.11.0](https://github.com/h5py/h5py/pull/2405) is released. At present, it will say:

```
  File "biom/_filter.pyx", line 1, in init biom._filter
    # -----------------------------------------------------------------------------
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```