### PR TITLE
Removed dependency on natsort

### DIFF
--- a/ci/aarch64.conda_requirements.txt
+++ b/ci/aarch64.conda_requirements.txt
@@ -1,4 +1,3 @@
-natsort >= 4.0.3
 numpy >= 1.9.2
 pandas >= 0.20.0
 scipy >= 1.3.1

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,4 +1,3 @@
-natsort >= 4.0.3
 numpy >= 1.9.2
 pandas >= 0.20.0
 scipy >= 1.3.1


### PR DESCRIPTION
The package `natsort` is listed as a dependency but it is actually never used. Instead, BIOM has a built-in `natsort` function. Therefore this dependency can be removed. See:

https://github.com/scikit-bio/scikit-bio/issues/2007