### PR TITLE
Testing NumPy 2.0 compatibility...

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@ BIOM-Format ChangeLog
 
 biom-2.1.16-dev
 ---------------
+* Testing NumPy 2.0 compatibility...
 
 biom 2.1.16
 -----------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ BIOM-Format ChangeLog
 
 biom-2.1.16-dev
 ---------------
-* Testing NumPy 2.0 compatibility...
+* Testing NumPy 2.0 compatibility... Again...
 
 biom 2.1.16
 -----------


### PR DESCRIPTION
NumPy 2.0 was released on Jun 16, 2024. CI workflows may break. Here is a test. Don't merge.