### PR TITLE
chore: ensure that package is built against numpy >=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools","wheel", "numpy", "cython"]
+requires = ["setuptools","wheel", "numpy ~=2.0", "cython"]


### PR DESCRIPTION
Fix #974 