### PR TITLE
Speedup import time with lazy imports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ BIOM-Format ChangeLog
 biom-2.1.16-dev
 ---------------
 
+Performance improvements:
+
+* Decreased execution time of `import biom` by half with lazy imports. See PR[#987](https://github.com/biocore/biom-format/pull/987)
+
 Maintenance:
 
 * Python 3.7 and 3.8 removed from CI as they are [end-of-life](https://devguide.python.org/versions/). Python 3.13 added to CI. See PR[#986](https://github.com/biocore/biom-format/pull/986).

--- a/biom/table.py
+++ b/biom/table.py
@@ -3232,6 +3232,7 @@ class Table:
 
         """
         import scipy.stats
+
         def f(val, id_, _):
             return scipy.stats.rankdata(val, method=method)
         return self.transform(f, axis=axis, inplace=inplace)

--- a/biom/table.py
+++ b/biom/table.py
@@ -172,8 +172,6 @@ Bacteria; Bacteroidetes   1.0 1.0 0.0 1.0
 # -----------------------------------------------------------------------------
 
 import numpy as np
-# import scipy.stats
-# import h5py
 from copy import deepcopy
 from datetime import datetime
 from json import dumps as _json_dumps, JSONEncoder
@@ -184,9 +182,7 @@ from collections.abc import Hashable, Iterable
 from numpy import ndarray, asarray, zeros, newaxis
 from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, isspmatrix,
                           vstack, hstack, dok_matrix)
-# import pandas as pd
 import re
-# import importlib
 from biom.exception import (TableException, UnknownAxisError, UnknownIDError,
                             DisjointIDError)
 from biom.util import (get_biom_format_version_string,
@@ -3236,7 +3232,6 @@ class Table:
 
         """
         import scipy.stats
-
         def f(val, id_, _):
             return scipy.stats.rankdata(val, method=method)
         return self.transform(f, axis=axis, inplace=inplace)
@@ -4112,7 +4107,6 @@ html
         ...                         axis='observation') # doctest: +SKIP
         """
         import h5py
-
         if not isinstance(h5grp, (h5py.Group, h5py.File)):
             raise ValueError("h5grp does not appear to be an HDF5 file or "
                              "group")

--- a/biom/table.py
+++ b/biom/table.py
@@ -172,8 +172,8 @@ Bacteria; Bacteroidetes   1.0 1.0 0.0 1.0
 # -----------------------------------------------------------------------------
 
 import numpy as np
-import scipy.stats
-import h5py
+# import scipy.stats
+# import h5py
 from copy import deepcopy
 from datetime import datetime
 from json import dumps as _json_dumps, JSONEncoder
@@ -186,12 +186,13 @@ from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, isspmatrix,
                           vstack, hstack, dok_matrix)
 # import pandas as pd
 import re
+# import importlib
 from biom.exception import (TableException, UnknownAxisError, UnknownIDError,
                             DisjointIDError)
 from biom.util import (get_biom_format_version_string,
                        get_biom_format_url_string, flatten, natsort,
                        prefer_self, index_list, H5PY_VLEN_STR,
-                       __format_version__, LazyMixin)
+                       __format_version__)
 from biom.err import errcheck
 from ._filter import _filter
 from ._transform import _transform
@@ -388,7 +389,7 @@ def vlen_list_of_str_formatter(grp, header, md, compression):
         compression=compression)
 
 
-class Table(LazyMixin):
+class Table:
     """The (canonically pronounced 'teh') Table.
 
     Give in to the power of the Table!
@@ -3234,6 +3235,8 @@ class Table(LazyMixin):
         o4	1.0	4.0	1.0
 
         """
+        import scipy.stats
+
         def f(val, id_, _):
             return scipy.stats.rankdata(val, method=method)
         return self.transform(f, axis=axis, inplace=inplace)
@@ -4108,6 +4111,8 @@ html
         >>>     t = Table.from_hdf5(f, ids=["GG_OTU_1"],
         ...                         axis='observation') # doctest: +SKIP
         """
+        import h5py
+
         if not isinstance(h5grp, (h5py.Group, h5py.File)):
             raise ValueError("h5grp does not appear to be an HDF5 file or "
                              "group")
@@ -4341,13 +4346,13 @@ html
         index = self.ids(axis='observation')
         columns = self.ids()
 
-        self._get_pd()
+        import pandas as pd
         if dense:
             mat = self.matrix_data.toarray()
-            constructor = self.pd.DataFrame
+            constructor = pd.DataFrame
         else:
             mat = self.matrix_data.copy()
-            constructor = partial(self.pd.DataFrame.sparse.from_spmatrix)
+            constructor = partial(pd.DataFrame.sparse.from_spmatrix)
 
         return constructor(mat, index=index, columns=columns)
 
@@ -4443,7 +4448,7 @@ html
         O1   Bacteria     Firmicutes
         O2   Bacteria  Bacteroidetes
         """
-        self._get_pd()
+        import pandas as pd
         md = self.metadata(axis=axis)
         if md is None:
             raise KeyError("%s does not have metadata" % axis)
@@ -4474,7 +4479,7 @@ html
                     row.append(value)
             rows.append(row)
 
-        return self.pd.DataFrame(rows, index=self.ids(axis=axis), columns=mcols)
+        return pd.DataFrame(rows, index=self.ids(axis=axis), columns=mcols)
 
     def to_hdf5(self, h5grp, generated_by, compress=True, format_fs=None,
                 creation_date=None):

--- a/biom/util.py
+++ b/biom/util.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 import io
 import codecs
 import functools
-import importlib
 
 from collections import defaultdict
 from os import getenv
@@ -505,22 +504,3 @@ def is_hdf5_file(fp):
     with open(fp, 'rb') as f:
         # from the HDF5 documentation about format signature
         return f.read(8) == b'\x89HDF\r\n\x1a\n'
-
-
-class LazyMixin:
-    """A class for implementing lazy import of modules."""
-
-    def _get_pd(self):
-        """Import pandas."""
-        msg = "This function requires pandas."
-        if hasattr(self, "pd"):
-            if self.pd is None:
-                raise ImportError(msg)
-            return
-        try:
-            self.pd = importlib.import_module('pandas')
-        except ImportError:
-            self.pd = None
-            raise ImportError(msg)
-        # else:
-        #     self.pd = import

--- a/biom/util.py
+++ b/biom/util.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 import io
 import codecs
 import functools
+import importlib
 
 from collections import defaultdict
 from os import getenv
@@ -504,3 +505,22 @@ def is_hdf5_file(fp):
     with open(fp, 'rb') as f:
         # from the HDF5 documentation about format signature
         return f.read(8) == b'\x89HDF\r\n\x1a\n'
+
+
+class LazyMixin:
+    """A class for implementing lazy import of modules."""
+
+    def _get_pd(self):
+        """Import pandas."""
+        msg = "This function requires pandas."
+        if hasattr(self, "pd"):
+            if self.pd is None:
+                raise ImportError(msg)
+            return
+        try:
+            self.pd = importlib.import_module('pandas')
+        except ImportError:
+            self.pd = None
+            raise ImportError(msg)
+        # else:
+        #     self.pd = import


### PR DESCRIPTION
Addresses #984 

The average import time (`python -X importtime -c 'import biom'`) over 7 runs for the current master branch of BIOM is 0.44s. Moving the imports of the required dependencies into their respective functions brings the average import time down to 0.19s, a **2.3x** speedup.

Performance of individual functions is only impacted on the first call. For example, the first call to `Table.to_dataframe()` is 247 microseconds, while all subsequent calls are 180 microseconds. This is due to the module being cached in `sys.modules` after the first call. The execution time of `to_dataframe()` without the import statement inside the function is 180 microseconds.