### PR TITLE
Fixing a typo in docstring

### DIFF
--- a/biom/table.py
+++ b/biom/table.py
@@ -395,7 +395,7 @@ class Table:
     versions 2.0 and 2.1 are based on HDF5. For more information see [1]_
     and [2]_
 
-    Paramaters
+    Parameters
     ----------
     data : array_like
         An (N,M) sample by observation matrix represented as one of these


### PR DESCRIPTION
This typo causes a warning when rendering the documentation using Sphinx:

```
UserWarning: Unknown section Paramaters in the docstring of Table
```