### PR TITLE
Schlich/issue970

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -109,4 +109,32 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: make test
-  
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for ARM builds on Linux, optional)
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+        env:
+          # If you need to build for ARM on macOS, you'll need to set this.
+          # CIBW_ARCHS_MACOS: "x86_64 aarch64"
+
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ R-code/biom.Rcheck*
 
 # Sphinx builds
 doc/documentation/generated
+wheelhouse/

--- a/ci/conda_host_env.yml
+++ b/ci/conda_host_env.yml
@@ -8,5 +8,6 @@ dependencies:
   - hdf5
   - pip
   - cython
+  - gcc
   - pip:
       - "-r requirements.test.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,99 @@
 [build-system]
-requires = ["setuptools","wheel", "numpy", "cython"]
+requires = ["setuptools>=61.0","wheel", "numpy", "cython"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "biom_format"
+version = "2.1.16-dev"
+description = "Biological Observation Matrix (BIOM) format"
+requires-python = ">= 3.6"
+readme = "README.md"
+authors = [
+    {name = "Daniel McDonald", email = "mcdonadt@colorado.edu"},
+    {name = "Greg Caporaso", email = ""},
+    {name = "Jai Ram Rideout", email = ""},
+    {name = "Jose Clemente", email = ""},
+    {name = "Jorge Cañardo Alastuey", email = ""},
+    {name = "Michael Hall", email = ""},
+]
+license = { text = "BSD" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+]
+dependencies = [
+    "click",
+    "numpy >= 1.9.2",
+    "scipy >= 1.3.1",
+    "pandas >= 0.20.0",
+    "h5py",
+]
+
+[project.optional-dependencies]
+# Corresponds to the old `extras_require`
+test = [
+    "pytest>=6.2.4",
+    "pytest-cov",
+    "flake8",
+]
+hdf5 = ["h5py >= 2.2.0"]
+anndata = ["anndata"]
+
+[project.urls]
+Homepage = "http://www.biom-format.org"
+
+[project.scripts]
+biom = "biom.cli:cli"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+
+[tool.cibuildwheel]
+test-command = "pytest {project}/tests"
+test-requires = ["pytest"]
+
+[tool.pytest.ini_options]
+addopts = ["--ignore=biom/assets/exercise_api.py "]
+doctest_optionflags = [ "NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL" ]
+testpaths = ["biom"]
+
+[tool.flake8]
+exclude = ["biom/tests/long_lines.py"]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Biological Observation Matrix (BIOM) format"
 requires-python = ">= 3.6"
 readme = "README.md"
 authors = [
-    {name = "Daniel McDonald", email = "mcdonadt@colorado.edu"},
+    {name = "Daniel McDonald", email = "damcdonald@ucsd.edu"},
     {name = "Greg Caporaso", email = ""},
     {name = "Jai Ram Rideout", email = ""},
     {name = "Jose Clemente", email = ""},

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = --ignore=biom/assets/exercise_api.py 
-doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
-testpaths = biom

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[aliases]
-test=pytest
-
-[flake8]
-exclude=biom/tests/long_lines.py
-
-[options]
-python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -8,33 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import sys
-
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.extension import Extension
-import numpy as np
-from Cython.Build import cythonize
-
-# Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
-# in multiprocessing/util.py _exit_function when running `python
-# setup.py test` (see
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html),
-# borrowed from https://github.com/getsentry/sentry/blob/master/setup.py
-for m in ('multiprocessing', 'logging'):
-    try:
-        __import__(m)
-    except ImportError:
-        pass
-
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2011-2020, The BIOM Format Development Team"
-__credits__ = ["Greg Caporaso", "Daniel McDonald", "Jose Clemente",
-               "Jai Ram Rideout", "Jorge Cañardo Alastuey", "Michael Hall"]
-__license__ = "BSD"
-__version__ = "2.1.16-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
-
 
 long_description = """BIOM: Biological Observation Matrix
 http://www.biom-format.org
@@ -47,78 +22,22 @@ Folker Meyer, Rob Knight, J Gregory Caporaso
 GigaScience 2012, 1:7.
 """
 
-classes = """
-    Development Status :: 4 - Beta
-    License :: OSI Approved :: BSD License
-    Topic :: Scientific/Engineering :: Bio-Informatics
-    Topic :: Software Development :: Libraries :: Application Frameworks
-    Topic :: Software Development :: Libraries :: Python Modules
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    Operating System :: POSIX :: Linux
-    Operating System :: MacOS :: MacOS X
-    Operating System :: Microsoft :: Windows
-"""
-classifiers = [s.strip() for s in classes.split('\n') if s]
+def get_extensions():
+    import numpy as np
+    from Cython.Build import cythonize
 
-# Dealing with Cython
-ext = '.pyx'
-extensions = [Extension("biom._filter",
-                        ["biom/_filter" + ext],
-                        include_dirs=[np.get_include()]),
-              Extension("biom._transform",
-                        ["biom/_transform" + ext],
-                        include_dirs=[np.get_include()]),
-              Extension("biom._subsample",
-                        ["biom/_subsample" + ext],
-                        include_dirs=[np.get_include()])]
-extensions = cythonize(extensions)
-
-install_requires = [
-    "click",
-    "numpy >= 1.9.2",
-    "scipy >= 1.3.1",
-    'pandas >= 0.20.0',
-    "h5py",
-]
-
-if sys.version_info[0] < 3:
-    raise SystemExit("Python 2.7 is no longer supported")
+    extensions = [
+        Extension("biom._filter",
+                    ["biom/_filter.pyx"],
+                    include_dirs=[np.get_include()]),
+        Extension("biom._transform",
+                    ["biom/_transform.pyx"],
+                    include_dirs=[np.get_include()]),
+        Extension("biom._subsample",
+                    ["biom/_subsample.pyx"],
+                    include_dirs=[np.get_include()]),
+    ]
+    return cythonize(extensions)
 
 
-setup(name='biom-format',
-      version=__version__,
-      description='Biological Observation Matrix (BIOM) format',
-      long_description=long_description,
-      license=__license__,
-      author=__maintainer__,
-      author_email=__email__,
-      maintainer=__maintainer__,
-      maintainer_email=__email__,
-      url='http://www.biom-format.org',
-      packages=find_packages(),
-      tests_require=[
-          'pytest>=6.2.4',
-          'pytest-cov',
-          'flake8',
-      ],
-      include_package_data=True,
-      ext_modules=extensions,
-      include_dirs=[np.get_include()],
-      install_requires=install_requires,
-      extras_require={'hdf5': ["h5py >= 2.2.0"],
-                      'anndata': ["anndata"],
-                      },
-      classifiers=classifiers,
-      entry_points='''
-          [console_scripts]
-          biom=biom.cli:cli
-      ''')
+setup(ext_modules=get_extensions())


### PR DESCRIPTION
Closes #932 and #970 

This pull request introduces several significant changes to the project's build system, dependency management, and configuration files. The most notable updates include transitioning to `pyproject.toml` for project metadata and configuration, adding a GitHub Actions workflow for building Python wheels, and simplifying `setup.py` by delegating metadata to `pyproject.toml`. These changes aim to modernize the project's packaging and testing infrastructure.

### Build System Updates:
* Added a new GitHub Actions workflow (`.github/workflows/python-package-conda.yml`) to build Python wheels across multiple operating systems (Ubuntu, Windows, macOS) and upload them as artifacts. This includes support for ARM builds on Linux using QEMU.

### Dependency Management:
* Updated `ci/conda_host_env.yml` to include `gcc` as a dependency, ensuring compatibility with the updated build process.
* Transitioned dependency and metadata definitions to `pyproject.toml`, including build requirements (`setuptools>=61.0`) and runtime dependencies like `numpy`, `scipy`, and `pandas`.

### Configuration Modernization:
* Migrated project configuration from `setup.cfg` and `pytest.ini` to `pyproject.toml`, consolidating settings for tools like `pytest` and `flake8`. [[1]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L1-L8) [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L1-L4)

### Simplification of `setup.py`:
* Refactored `setup.py` to remove metadata definitions and streamline the extension-building process using a dedicated `get_extensions()` function. Metadata is now managed in `pyproject.toml`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L11-L37) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L50-R43)